### PR TITLE
Feature: 新增 會員導覽列

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-navigation-menu": "^1.2.4",
         "@radix-ui/react-slot": "^1.1.1",
+        "@radix-ui/react-tabs": "^1.1.3",
         "@supabase/supabase-js": "^2.48.0",
         "@tanstack/react-query": "^5.66.0",
         "@tanstack/react-query-devtools": "^5.66.0",
@@ -1624,6 +1625,134 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
       "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.3.tgz",
+      "integrity": "sha512-9mFyI30cuRDImbmFF6O2KUJdgEOsGh9Vmx9x/Dh9tOhL7BngmQPQfwW4aejKm5OHpfWIdmeV6ySyuxoOGjtNng==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-roving-focus": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.2.tgz",
+      "integrity": "sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.2.tgz",
+      "integrity": "sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-navigation-menu": "^1.2.4",
     "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-tabs": "^1.1.3",
     "@supabase/supabase-js": "^2.48.0",
     "@tanstack/react-query": "^5.66.0",
     "@tanstack/react-query-devtools": "^5.66.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,10 @@ function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="map" element={<Map />} />
           <Route path="member" element={<Member />}>
+            <Route
+              index
+              element={<Navigate replace to="normal/memberInfo" />}
+            />
             <Route path="normal">
               <Route index element={<Navigate replace to="memberInfo" />} />
               <Route path="memberInfo" element={<MemberInfo />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,10 +4,17 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import HomePage from "./pages/HomePage";
 import Map from "./pages/Map";
-import MemberInfo from "./pages/MemberInfo";
+import Member from "./pages/Member";
 import Signin from "./pages/Signin";
 import Signup from "./pages/Signup";
 import PageNotFound from "./pages/PageNotFound";
+import MemberInfo from "./components/MemberInfo";
+import PointRecords from "./components/PointRecords";
+import TransactionRecords from "./components/TransactionRecords";
+import AdmitInfo from "./components/AdmitInfo";
+import BoxesTable from "./components/BoxesTable";
+import RecyclingTable from "./components/RecyclingTable";
+import AdmitTransactionRecords from "./components/AdmitTransactionRecords";
 
 const queryClient = new QueryClient();
 
@@ -19,11 +26,17 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="map" element={<Map />} />
-          <Route path="member" element={<MemberInfo />}>
-            <Route index element={<MemberInfo />} />
-            <Route path="memberInfo" />
-            <Route path="pointsRecords" />
-            <Route path="transactionRecords" />
+          <Route path="member" element={<Member />}>
+            <Route path="memberInfo" element={<MemberInfo />} />
+            <Route path="pointsRecords" element={<PointRecords />} />
+            <Route path="transactionRecords" element={<TransactionRecords />} />
+            <Route path="admitInfo" element={<AdmitInfo />}></Route>
+            <Route path="boxesTable" element={<BoxesTable />}></Route>
+            <Route path="recyclingTable" element={<RecyclingTable />}></Route>
+            <Route
+              path="admitTransactionRecords"
+              element={<AdmitTransactionRecords />}
+            ></Route>
           </Route>
           <Route path="signin" element={<Signin />} />
           <Route path="signup" element={<Signup />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
@@ -27,6 +27,7 @@ function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="map" element={<Map />} />
           <Route path="member" element={<Member />}>
+            <Route index element={<Navigate replace to="memberInfo" />} />
             <Route path="memberInfo" element={<MemberInfo />} />
             <Route path="pointsRecords" element={<PointRecords />} />
             <Route path="transactionRecords" element={<TransactionRecords />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,17 +27,25 @@ function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="map" element={<Map />} />
           <Route path="member" element={<Member />}>
-            <Route index element={<Navigate replace to="memberInfo" />} />
-            <Route path="memberInfo" element={<MemberInfo />} />
-            <Route path="pointsRecords" element={<PointRecords />} />
-            <Route path="transactionRecords" element={<TransactionRecords />} />
-            <Route path="admitInfo" element={<AdmitInfo />} />
-            <Route path="boxesTable" element={<BoxesTable />} />
-            <Route path="recyclingTable" element={<RecyclingTable />} />
-            <Route
-              path="admitTransactionRecords"
-              element={<AdmitTransactionRecords />}
-            />
+            <Route path="normal">
+              <Route index element={<Navigate replace to="memberInfo" />} />
+              <Route path="memberInfo" element={<MemberInfo />} />
+              <Route path="pointsRecords" element={<PointRecords />} />
+              <Route
+                path="transactionRecords"
+                element={<TransactionRecords />}
+              />
+            </Route>
+            <Route path="admit">
+              <Route index element={<Navigate replace to="admitInfo" />} />
+              <Route path="admitInfo" element={<AdmitInfo />} />
+              <Route path="boxesTable" element={<BoxesTable />} />
+              <Route path="recyclingTable" element={<RecyclingTable />} />
+              <Route
+                path="admitTransactionRecords"
+                element={<AdmitTransactionRecords />}
+              />
+            </Route>
           </Route>
           <Route path="signin" element={<Signin />} />
           <Route path="signup" element={<Signup />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,13 +30,13 @@ function App() {
             <Route path="memberInfo" element={<MemberInfo />} />
             <Route path="pointsRecords" element={<PointRecords />} />
             <Route path="transactionRecords" element={<TransactionRecords />} />
-            <Route path="admitInfo" element={<AdmitInfo />}></Route>
-            <Route path="boxesTable" element={<BoxesTable />}></Route>
-            <Route path="recyclingTable" element={<RecyclingTable />}></Route>
+            <Route path="admitInfo" element={<AdmitInfo />} />
+            <Route path="boxesTable" element={<BoxesTable />} />
+            <Route path="recyclingTable" element={<RecyclingTable />} />
             <Route
               path="admitTransactionRecords"
               element={<AdmitTransactionRecords />}
-            ></Route>
+            />
           </Route>
           <Route path="signin" element={<Signin />} />
           <Route path="signup" element={<Signup />} />

--- a/src/components/AdmitInfo.jsx
+++ b/src/components/AdmitInfo.jsx
@@ -1,0 +1,5 @@
+function AdmitInfo() {
+  return <div>5-2 回收站點回收資訊總覽</div>;
+}
+
+export default AdmitInfo;

--- a/src/components/AdmitTransactionRecords.jsx
+++ b/src/components/AdmitTransactionRecords.jsx
@@ -1,0 +1,5 @@
+function AdmitTransactionRecords() {
+  return <div>5-5 紙箱交易紀錄</div>;
+}
+
+export default AdmitTransactionRecords;

--- a/src/components/BoxesTable.jsx
+++ b/src/components/BoxesTable.jsx
@@ -1,0 +1,5 @@
+function BoxesTable() {
+  return <div>5-3 待認領／自用紙箱列表</div>;
+}
+
+export default BoxesTable;

--- a/src/components/MemberInfo.jsx
+++ b/src/components/MemberInfo.jsx
@@ -1,0 +1,5 @@
+function MemberInfo() {
+  return <div>4-2 會員資訊總覽頁</div>;
+}
+
+export default MemberInfo;

--- a/src/components/MemberNav.jsx
+++ b/src/components/MemberNav.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { NavLink, Outlet } from "react-router-dom";
 
 const style = {
@@ -15,7 +15,11 @@ const style = {
 };
 
 function MemberNav() {
-  const [nav, setNav] = useState("normal");
+  const [nav, setNav] = useState(localStorage.getItem("nav") || "normal");
+  useEffect(() => {
+    localStorage.setItem("nav", nav); // 將 nav 的值儲存到 localStorage
+  }, [nav]); // 當 nav 改變時，更新 localStorage
+
   return (
     <>
       <div className="bg-[#F3F3F3]">

--- a/src/components/MemberNav.jsx
+++ b/src/components/MemberNav.jsx
@@ -1,5 +1,101 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Link, NavLink } from "react-router-dom";
+
+const style = {
+  TabsList:
+    "h-full w-full gap-2 rounded-none bg-[#F3F3F3] p-0 md:justify-start",
+  TabListContainer: "container mx-auto",
+  TabsTrigger:
+    "h-[77px] w-[168px] rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-[#FFFFFF] p-6 text-[#6F6F6F] data-[state=active]:bg-main-600 data-[state=active]:text-white",
+  TabsContentContainer: "container mx-auto flex justify-between text-[#6F6F6F]",
+  NavLink: "text-center py-[23px] grow",
+  active: "grow border-b-4 border-main-600 py-[23px] text-center text-main-600",
+};
 function MemberNav() {
-  return <div>會員後臺4-2、4-3、4-4 切分頁元件</div>;
+  return (
+    <Tabs defaultValue="member">
+      <div className="bg-[#F3F3F3]">
+        <div className={style.TabListContainer}>
+          <TabsList className={style.TabsList}>
+            <TabsTrigger value="member" className={style.TabsTrigger}>
+              <Link to="/member/memberInfo">
+                <h4>會員頁面</h4>
+              </Link>
+            </TabsTrigger>
+            <TabsTrigger value="admit" className={style.TabsTrigger}>
+              <Link to="/member/admitInfo">
+                <h4>管理者頁面</h4>
+              </Link>
+            </TabsTrigger>
+          </TabsList>
+        </div>
+      </div>
+      <TabsContent value="member" className="bg-white">
+        <div className={style.TabsContentContainer}>
+          <NavLink
+            to="memberInfo"
+            className={({ isActive }) =>
+              isActive ? style.active : style.NavLink
+            }
+          >
+            <h5>會員資訊</h5>
+          </NavLink>
+          <NavLink
+            to="pointsRecords"
+            className={({ isActive }) =>
+              isActive ? style.active : style.NavLink
+            }
+          >
+            <h5>積分紀錄</h5>
+          </NavLink>
+          <NavLink
+            to="transactionRecords"
+            className={({ isActive }) =>
+              isActive ? style.active : style.NavLink
+            }
+          >
+            <h5>交易紀錄</h5>
+          </NavLink>
+        </div>
+      </TabsContent>
+      <TabsContent value="admit">
+        <div className={style.TabsContentContainer}>
+          <NavLink
+            to="admitInfo"
+            className={({ isActive }) =>
+              isActive ? style.active : style.NavLink
+            }
+          >
+            <h5>站點概述</h5>
+          </NavLink>
+          <NavLink
+            to="boxesTable"
+            className={({ isActive }) =>
+              isActive ? style.active : style.NavLink
+            }
+          >
+            <h5>可認領紙箱列表</h5>
+          </NavLink>
+          <NavLink
+            to="recyclingTable"
+            className={({ isActive }) =>
+              isActive ? style.active : style.NavLink
+            }
+          >
+            <h5>待回收紙箱列表</h5>
+          </NavLink>
+          <NavLink
+            to="admitTransactionRecords"
+            className={({ isActive }) =>
+              isActive ? style.active : style.NavLink
+            }
+          >
+            <h5>交易紀錄</h5>
+          </NavLink>
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
 }
 
 export default MemberNav;

--- a/src/components/MemberNav.jsx
+++ b/src/components/MemberNav.jsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet, useLocation } from "react-router-dom";
 
 const style = {
   mainNavContainer:
@@ -15,10 +14,19 @@ const style = {
 };
 
 function MemberNav() {
-  const [nav, setNav] = useState(localStorage.getItem("nav") || "normal");
-  useEffect(() => {
-    localStorage.setItem("nav", nav); // 將 nav 的值儲存到 localStorage
-  }, [nav]); // 當 nav 改變時，更新 localStorage
+  const location = useLocation();
+
+  const getNavType = () => {
+    if (location.pathname.startsWith("/member/normal")) {
+      return "normal";
+    } else if (location.pathname.startsWith("/member/admit")) {
+      return "admit";
+    } else {
+      return "normal"; // 預設值
+    }
+  };
+
+  const navType = getNavType();
 
   return (
     <>
@@ -30,7 +38,6 @@ function MemberNav() {
             className={({ isActive }) =>
               isActive ? style.mainNavActive : style.mainNav
             }
-            onClick={() => setNav("normal")}
           >
             <h4>會員頁面</h4>
           </NavLink>
@@ -39,13 +46,12 @@ function MemberNav() {
             className={({ isActive }) =>
               isActive ? style.mainNavActive : style.mainNav
             }
-            onClick={() => setNav("admit")}
           >
             <h4>管理者頁面</h4>
           </NavLink>
         </div>
       </div>
-      {nav === "normal" ? <NormalNav /> : <AdmitNav />}
+      {navType === "normal" ? <NormalNav /> : <AdmitNav />}
       <div className="container mx-auto">
         <Outlet />
       </div>

--- a/src/components/MemberNav.jsx
+++ b/src/components/MemberNav.jsx
@@ -1,101 +1,125 @@
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Link, NavLink } from "react-router-dom";
+import { useState } from "react";
+import { NavLink, Outlet } from "react-router-dom";
 
 const style = {
-  TabsList:
-    "h-full w-full gap-2 rounded-none bg-[#F3F3F3] p-0 md:justify-start",
-  TabListContainer: "container mx-auto",
-  TabsTrigger:
-    "h-[77px] w-[168px] rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-[#FFFFFF] p-6 text-[#6F6F6F] data-[state=active]:bg-main-600 data-[state=active]:text-white",
-  TabsContentContainer: "container mx-auto flex justify-between text-[#6F6F6F]",
-  NavLink: "text-center py-[23px] grow",
-  active: "grow border-b-4 border-main-600 py-[23px] text-center text-main-600",
+  mainNavContainer:
+    "container mx-auto flex w-full justify-center gap-2 md:justify-start",
+  mainNav:
+    "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-white text-[#6F6F6F]",
+  mainNavActive:
+    "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-main-600 text-white",
+  secondNavContainer: "container mx-auto flex gap-2 overflow-x-auto",
+  secondNav: "grow py-[23px] text-center text-[#6F6F6F] text-nowrap",
+  secondActive:
+    "grow border-b-4 border-main-600 py-[23px] text-center text-main-600 text-nowrap",
 };
+
 function MemberNav() {
+  const [nav, setNav] = useState("normal");
   return (
-    <Tabs defaultValue="member">
+    <>
       <div className="bg-[#F3F3F3]">
-        <div className={style.TabListContainer}>
-          <TabsList className={style.TabsList}>
-            <TabsTrigger value="member" className={style.TabsTrigger}>
-              <Link to="/member/memberInfo">
-                <h4>會員頁面</h4>
-              </Link>
-            </TabsTrigger>
-            <TabsTrigger value="admit" className={style.TabsTrigger}>
-              <Link to="/member/admitInfo">
-                <h4>管理者頁面</h4>
-              </Link>
-            </TabsTrigger>
-          </TabsList>
+        {/* TabTrigger */}
+        <div className={style.mainNavContainer}>
+          <NavLink
+            to="/member/normal"
+            className={({ isActive }) =>
+              isActive ? style.mainNavActive : style.mainNav
+            }
+            onClick={() => setNav("normal")}
+          >
+            <h4>會員頁面</h4>
+          </NavLink>
+          <NavLink
+            to="/member/admit"
+            className={({ isActive }) =>
+              isActive ? style.mainNavActive : style.mainNav
+            }
+            onClick={() => setNav("admit")}
+          >
+            <h4>管理者頁面</h4>
+          </NavLink>
         </div>
       </div>
-      <TabsContent value="member" className="bg-white">
-        <div className={style.TabsContentContainer}>
-          <NavLink
-            to="memberInfo"
-            className={({ isActive }) =>
-              isActive ? style.active : style.NavLink
-            }
-          >
-            <h5>會員資訊</h5>
-          </NavLink>
-          <NavLink
-            to="pointsRecords"
-            className={({ isActive }) =>
-              isActive ? style.active : style.NavLink
-            }
-          >
-            <h5>積分紀錄</h5>
-          </NavLink>
-          <NavLink
-            to="transactionRecords"
-            className={({ isActive }) =>
-              isActive ? style.active : style.NavLink
-            }
-          >
-            <h5>交易紀錄</h5>
-          </NavLink>
-        </div>
-      </TabsContent>
-      <TabsContent value="admit">
-        <div className={style.TabsContentContainer}>
-          <NavLink
-            to="admitInfo"
-            className={({ isActive }) =>
-              isActive ? style.active : style.NavLink
-            }
-          >
-            <h5>站點概述</h5>
-          </NavLink>
-          <NavLink
-            to="boxesTable"
-            className={({ isActive }) =>
-              isActive ? style.active : style.NavLink
-            }
-          >
-            <h5>可認領紙箱列表</h5>
-          </NavLink>
-          <NavLink
-            to="recyclingTable"
-            className={({ isActive }) =>
-              isActive ? style.active : style.NavLink
-            }
-          >
-            <h5>待回收紙箱列表</h5>
-          </NavLink>
-          <NavLink
-            to="admitTransactionRecords"
-            className={({ isActive }) =>
-              isActive ? style.active : style.NavLink
-            }
-          >
-            <h5>交易紀錄</h5>
-          </NavLink>
-        </div>
-      </TabsContent>
-    </Tabs>
+      {nav === "normal" ? <NormalNav /> : <AdmitNav />}
+      <div className="container mx-auto">
+        <Outlet />
+      </div>
+    </>
   );
 }
 
+function NormalNav() {
+  return (
+    <div className="bg-white">
+      <div className={style.secondNavContainer}>
+        <NavLink
+          to="normal/memberInfo"
+          className={({ isActive }) =>
+            isActive ? style.secondActive : style.secondNav
+          }
+        >
+          <h4>會員頁面</h4>
+        </NavLink>
+        <NavLink
+          to="normal/pointsRecords"
+          className={({ isActive }) =>
+            isActive ? style.secondActive : style.secondNav
+          }
+        >
+          <h4>積分紀錄</h4>
+        </NavLink>
+        <NavLink
+          to="normal/transactionRecords"
+          className={({ isActive }) =>
+            isActive ? style.secondActive : style.secondNav
+          }
+        >
+          <h4>交易紀錄</h4>
+        </NavLink>
+      </div>
+    </div>
+  );
+}
+
+function AdmitNav() {
+  return (
+    <div className="bg-white">
+      <div className={style.secondNavContainer}>
+        <NavLink
+          to="admit/admitInfo"
+          className={({ isActive }) =>
+            isActive ? style.secondActive : style.secondNav
+          }
+        >
+          <h4>站點概況</h4>
+        </NavLink>
+        <NavLink
+          to="admit/boxesTable"
+          className={({ isActive }) =>
+            isActive ? style.secondActive : style.secondNav
+          }
+        >
+          <h4>可認領紙箱列表</h4>
+        </NavLink>
+        <NavLink
+          to="admit/recyclingTable"
+          className={({ isActive }) =>
+            isActive ? style.secondActive : style.secondNav
+          }
+        >
+          <h4>待回收紙箱列表</h4>
+        </NavLink>
+        <NavLink
+          to="admit/admitTransactionRecords"
+          className={({ isActive }) =>
+            isActive ? style.secondActive : style.secondNav
+          }
+        >
+          <h4>交易紀錄</h4>
+        </NavLink>
+      </div>
+    </div>
+  );
+}
 export default MemberNav;

--- a/src/components/PointRecords.jsx
+++ b/src/components/PointRecords.jsx
@@ -1,0 +1,5 @@
+function PointRecords() {
+  return <div>4-3 一般會員 - 歷史積分紀錄列表</div>;
+}
+
+export default PointRecords;

--- a/src/components/RecyclingTable.jsx
+++ b/src/components/RecyclingTable.jsx
@@ -1,0 +1,5 @@
+function RecyclingTable() {
+  return <div>5-4 待回收紙箱列表（報廢）</div>;
+}
+
+export default RecyclingTable;

--- a/src/components/TransactionRecords.jsx
+++ b/src/components/TransactionRecords.jsx
@@ -1,0 +1,5 @@
+function transactionRecords() {
+  return <div>4-4 一般會員 - 歷史回收記錄列表</div>;
+}
+
+export default transactionRecords;

--- a/src/components/ui/tabs.jsx
+++ b/src/components/ui/tabs.jsx
@@ -1,0 +1,41 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props} />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props} />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props} />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/pages/AdminInfo.jsx
+++ b/src/pages/AdminInfo.jsx
@@ -1,5 +1,0 @@
-function AdminInfo() {
-  return <div>5-1回收站點管理者後台 - 回收站管理者資訊頁</div>;
-}
-
-export default AdminInfo;

--- a/src/pages/Member.jsx
+++ b/src/pages/Member.jsx
@@ -1,7 +1,7 @@
 import Header from "@/components/Header";
 import MemberBanner from "@/components/MemberBanner";
 import Footer from "@/components/Footer";
-import { Outlet } from "react-router-dom";
+
 import MemberNav from "@/components/MemberNav";
 
 function Member() {
@@ -10,7 +10,6 @@ function Member() {
       <Header />
       <MemberBanner />
       <MemberNav />
-      <Outlet />
       <Footer />
     </div>
   );

--- a/src/pages/Member.jsx
+++ b/src/pages/Member.jsx
@@ -1,15 +1,19 @@
 import Header from "@/components/Header";
 import MemberBanner from "@/components/MemberBanner";
 import Footer from "@/components/Footer";
+import { Outlet } from "react-router-dom";
+import MemberNav from "@/components/MemberNav";
 
-function MemberInfo() {
+function Member() {
   return (
     <div>
       <Header />
       <MemberBanner />
+      <MemberNav />
+      <Outlet />
       <Footer />
     </div>
   );
 }
 
-export default MemberInfo;
+export default Member;


### PR DESCRIPTION
## Feature: 新增 會員導覽列（MemberNav.jsx）

### 任務項目
- 新增會員導覽列元件

### 實際調整
- 調整App.jsx：以會員+管理者身分來設定路由，調整如下：
  - 會員(member)
    - 會員頁面(normal)
      - 4-2 會員資訊總覽頁（member/normal/memberInfo）
      - 4-3 一般會員 - 歷史積分紀錄列﻿表（member/normal/pointsRecords）
      - 4-4 一般會員 - 歷史回收記錄列表（member/normal/transactionRecords）
    - 管理者頁面(admit)
      - 5-2 回收站點回收資訊總覽（member/admit/admitInfo）
      - 5-3 待認領／自用紙箱列表（member/admit/boxesTable）
      - 5-4 待回收紙箱列表（報廢）（member/admit/recyclingTable）
      - 5-5 紙箱交易紀錄（member/recyclingTable）
- 新增會員導覽列元件（MemberNav.jsx）  
- 新增會員頁面及管理者頁面內頁元件至components資料夾，包含：
    - 4-2 會員資訊總覽頁（MemberInfo.jsx）
    - 4-3 一般會員 - 歷史積分紀錄列﻿表（PointRecords.jsx）
    - 4-4 一般會員 - 歷史回收記錄列表（TransactionRecords.jsx）
    - 5-2 回收站點回收資訊總覽（AdmitInfo.jsx）
    - 5-3 待認領／自用紙箱列表（BoxesTable.jsx）
    - 5-4 待回收紙箱列表（報廢）（RecyclingTable.jsx）
    - 5-5 紙箱交易紀錄（AdmitTransactionRecords.jsx）
    
   issue #10 