### PR TITLE
feat: 調整 apiGetStations & apiGetStationById 回傳內容，更新 useStation Hook 支援 routeId 或 clickedId

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,11 +1,17 @@
+import { useState } from "react";
+import { Button } from "./ui/button";
+
+import { useStation } from "@/hooks/useStation";
 import { useStations } from "@/hooks/useStations";
 
+import MapNav from "./MapNav";
 import Spinner from "@/components/Spinner";
 import ErrorMessage from "./ErrorMessage";
-import MapNav from "./MapNav";
 
 function Map() {
+  const [clickedId, setClickedId] = useState(null);
   const { stations, isLoadingStations, stationsError } = useStations();
+  const { station, isLoadingStation, stationError } = useStation(clickedId);
 
   if (isLoadingStations) return <Spinner />;
   if (stationsError) return <ErrorMessage error={stationsError} />;
@@ -15,15 +21,37 @@ function Map() {
       <MapNav />
       <main>
         <h3>Map</h3>
-        <ul className="mx-4 list-disc px-8">
-          {stations.map((station) => (
-            <li key={station.id}>{station.station_name}</li>
-          ))}
-        </ul>
+        <div className="my-10">
+          <h4>營業時間</h4>
+          {isLoadingStation && <Spinner />}
+          {station && (
+            <ul>
+              {station.station_daily_hours.map((el) => (
+                <li key={el.id}>open time: {el.open_time}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div>
+          <h4>所有站點</h4>
+          <ul className="mx-4 list-disc px-8">
+            {stations.map((station) => (
+              <li key={station.id}>
+                {station.station_name}
+                <Button
+                  className="ms-4"
+                  onClick={() => setClickedId(station.id)}
+                  variant="outline"
+                >
+                  click me!
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </div>
       </main>
     </>
   );
 }
 
 export default Map;
-Map;

--- a/src/hooks/useStation.js
+++ b/src/hooks/useStation.js
@@ -4,15 +4,21 @@ import { useParams } from "react-router-dom";
 /**
  * 自訂 Hook：使用 React Query 來取得單一站點資料
  *
- * 使用 `useQuery` 來向 API 請求站點資料，並處理資料加載與錯誤狀態。
+ * 該 Hook 根據路由參數（`stationId`）或傳入的 `clickedId` 來向 API 請求站點資料，並處理資料加載與錯誤狀態。
+ * - 若 `stationId` 存在於路由，會自動根據路由參數請求資料。
+ * - 若使用者點擊後提供 `clickedId`，會根據該 `clickedId` 請求資料。
+ *
+ * @param {string|null} clickedId - 用戶點擊後傳入的站點 ID，若未點擊則為 `null`。這會作為優先於路由 ID 的請求參數。
  *
  * @returns {Object} 返回包含三個屬性的物件：
- *   - `station` {Object|null} - 單一站點資料物件，若尚未請求或發生錯誤則為 `null`
- *   - `isLoadingStation` {boolean} - 是否正在加載資料
- *   - `stationError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
+ *   - `station` {Object|null} - 單一站點資料物件，若尚未請求或發生錯誤則為 `null`。
+ *   - `isLoadingStation` {boolean} - 是否正在加載資料。
+ *   - `stationError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`。
  */
-export function useStation() {
-  const { stationId } = useParams();
+export function useStation(clickedId) {
+  const { stationId: routeId } = useParams();
+
+  const stationId = routeId || clickedId;
 
   const {
     data: station,
@@ -21,7 +27,7 @@ export function useStation() {
   } = useQuery({
     queryKey: ["station", stationId],
     queryFn: () => apiGetStationById(stationId),
-    retry: false,
+    enabled: !!stationId,
   });
 
   return { station, isLoadingStation, stationError };

--- a/src/services/apiStations.js
+++ b/src/services/apiStations.js
@@ -12,7 +12,9 @@ import supabase from "./supabase";
  */
 export async function apiGetStations() {
   try {
-    let { data: stations, error } = await supabase.from("stations").select("*");
+    let { data: stations, error } = await supabase
+      .from("stations")
+      .select(`id, station_name, latitude, longitude`);
 
     if (error) throw error;
 
@@ -31,7 +33,7 @@ export async function apiGetStationById(stationId) {
   try {
     let { data: station, error } = await supabase
       .from("stations")
-      .select("*")
+      .select(`*,station_daily_hours(id,open_time,close_time,day_of_week)`)
       .eq("id", stationId)
       .single();
     if (error) throw error;


### PR DESCRIPTION
### 背景
針對讀取所有站點 API 及 useStation Hook 進行優化，避免讀取所有站點資訊，回傳過多不必要資料。

### 主要修改
1. 優化 apiGetStations & apiGetStationById 回傳內容
    -  apiGetStations 回傳所有站點定位資訊
    -  apiGetStationById 根據回傳單一站點詳細資訊 + 營業時間

2. 更新 useStation Hook，支援 routeId & clickedId 兩種獲取方式
    - 透過 routeId 獲取站點資訊（適用於直接進入 /map/:stationId 詳細頁面）。
    - 透過 clickedId 獲取站點資訊（適用於地圖或列表點擊後再請求詳細資料）。
    - 加入 enabled: !!stationId，確保 stationId 存在時才發送 API 請求，避免不必要的請求負擔。

### 影響範圍
- API 讀取邏輯 (apiStations.js)，影響所有站點與單一站點的請求。
- 自訂 Hook (hooks/useStation.js)，影響單一站點詳細資料的請求方式與觸發條件。

---

### 測試方式
- [ ] 呼叫 useStations 是否能取得所有站點定位資料？
- [ ] 呼叫 useStation(stationId) 是否能取得單一站點詳細資料+營業時間？
- [ ] 進入 /map 頁面是否能取得所有站點定位資料？
- [ ] 進入 /map 頁面點擊站點是否能取得單一站點詳細資料+營業時間？
- [ ] 進入 /map/:stationId 頁面是否能正確取得特定站點資訊？

---

關聯 Issue  #15
