### PR TITLE
feat: 完成一般使用者「註冊、登入、登出」 api 請求邏輯

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4687,6 +4687,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -6688,6 +6696,22 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/src/components/form/SigninForm.jsx
+++ b/src/components/form/SigninForm.jsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -16,6 +15,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 
+import { useSignIn } from "@/hooks/useSignIn";
+
 // zod驗證規則
 const formSchema = z.object({
   email: z
@@ -28,37 +29,25 @@ const formSchema = z.object({
     .min(8, { message: "密碼長度至少為 8 個字元" }),
 });
 
+// storeOwner
+// test01@gmail.com
+// password1
 function SigninForm() {
   const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      email: "",
-      password: "",
+      email: "test01@gmail.com",
+      password: "password1",
     },
   });
-  const { reset, formState } = form;
-  const { isSubmitSuccessful } = formState;
+  const { reset } = form;
+  const { signIn, isLoading } = useSignIn();
 
   // 表單提交
-  function onSubmit(values) {
-    try {
-      console.log(values);
-      // toast(
-      //   <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-      //     <code className="text-white">{JSON.stringify(values, null, 2)}</code>
-      //   </pre>,
-      // );
-    } catch (error) {
-      console.error("Form submission error", error);
-      // toast.error("Failed to submit the form. Please try again.");
-    }
-  }
-
-  useEffect(() => {
-    if (isSubmitSuccessful) {
-      reset();
-    }
-  }, [isSubmitSuccessful, reset]);
+  const onSubmit = (values) =>
+    signIn(values, {
+      onSettled: () => reset(),
+    });
 
   return (
     <Form {...form}>
@@ -103,8 +92,9 @@ function SigninForm() {
             </FormItem>
           )}
         />
-
-        <Button type="submit">登入</Button>
+        <Button type="submit" disabled={isLoading}>
+          登入
+        </Button>
       </form>
     </Form>
   );

--- a/src/components/form/SignupForm.jsx
+++ b/src/components/form/SignupForm.jsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -15,6 +14,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
+
+import { useSignUp } from "@/hooks/useSignUp";
 
 // zod驗證規則
 const formSchema = z.object({
@@ -33,34 +34,18 @@ function SigninForm() {
   const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      username: "",
-      email: "",
-      password: "",
+      username: "ollieeeee",
+      email: "1111@test.com",
+      password: "12345678",
     },
   });
-  const { reset, formState } = form;
-  const { isSubmitSuccessful } = formState;
+  const { reset } = form;
+  const { signUp, isLoading } = useSignUp();
 
   // 表單提交
-  function onSubmit(values) {
-    try {
-      console.log(values);
-      // toast(
-      //   <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
-      //     <code className="text-white">{JSON.stringify(values, null, 2)}</code>
-      //   </pre>,
-      // );
-    } catch (error) {
-      console.error("Form submission error", error);
-      // toast.error("Failed to submit the form. Please try again.");
-    }
+  function onSubmit({ username, email, password }) {
+    signUp({ username, email, password }, { onSettled: () => reset() });
   }
-  // 表單重置
-  useEffect(() => {
-    if (isSubmitSuccessful) {
-      reset();
-    }
-  }, [isSubmitSuccessful, reset]);
 
   return (
     <Form {...form}>
@@ -124,7 +109,9 @@ function SigninForm() {
           )}
         />
 
-        <Button type="submit">註冊</Button>
+        <Button type="submit" disabled={isLoading}>
+          註冊
+        </Button>
       </form>
     </Form>
   );

--- a/src/hooks/useSignIn.js
+++ b/src/hooks/useSignIn.js
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { apiSignIn } from "@/services/apiAuth";
+
+import toast from "react-hot-toast";
+
+export function useSignIn() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const { mutate: signIn, isPending: isLoading } = useMutation({
+    mutationKey: ["signIn"],
+    mutationFn: ({ email, password }) => apiSignIn({ email, password }),
+    onSuccess: (user) => {
+      // 1. user 緩存資料
+      queryClient.setQueryData(["user"], user);
+
+      // 2. token 存入 cookies
+      const { session } = user;
+      const expires = new Date(session.expires_at * 1000).toUTCString();
+      document.cookie = `accessToken=${session.access_token};expires=${expires}`;
+
+      // 3. UI 提示訊息
+      toast.success(`登入成功`);
+
+      // 4. 跳轉回資訊頁
+      navigate("/member", { replace: true });
+    },
+    onError: (error) => {
+      console.log(error.message);
+      toast.error(`登入失敗，帳號或密碼錯誤`);
+    },
+  });
+
+  return { signIn, isLoading };
+}

--- a/src/hooks/useSignIn.js
+++ b/src/hooks/useSignIn.js
@@ -24,7 +24,7 @@ export function useSignIn() {
       toast.success(`登入成功`);
 
       // 4. 跳轉回資訊頁
-      navigate("/member", { replace: true });
+      navigate("/", { replace: true });
     },
     onError: (error) => {
       console.log(error.message);

--- a/src/hooks/useSignOut.js
+++ b/src/hooks/useSignOut.js
@@ -1,0 +1,29 @@
+import { apiSignOut } from "@/services/apiAuth";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import toast from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
+
+export function useSignOut() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const { mutate: signOut, isPending: isLoading } = useMutation({
+    mutationKey: ["signOut"],
+    mutationFn: apiSignOut,
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: ["user"], exact: true });
+      document.cookie = "accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC;";
+      toast.success(`您已登出`);
+
+      navigate(`/`, { replace: true });
+    },
+
+    onError: (error) => {
+      console.error(error);
+      toast.error(`登出時發生錯誤`);
+    },
+  });
+
+  return { signOut, isLoading };
+}

--- a/src/hooks/useSignUp.js
+++ b/src/hooks/useSignUp.js
@@ -1,0 +1,46 @@
+import { useNavigate } from "react-router-dom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { apiSignUp } from "@/services/apiAuth";
+
+import toast from "react-hot-toast";
+
+export function useSignUp() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const { mutate: signUp, isPending: isLoading } = useMutation({
+    mutationKey: ["signUp"],
+    mutationFn: apiSignUp,
+    onSuccess: (user) => {
+      // 1. user 資料加入緩存
+      queryClient.setQueryData(["user"], user);
+
+      // 2. token 存 cookie
+      const { session } = user;
+      const expires = new Date(session.expires_at * 1000).toUTCString();
+      document.cookie = `accessToken=${session.access_token};expires=${expires}`;
+
+      // 3. UI 提示訊息
+      toast.success(`註冊成功`);
+
+      // 4. 導回資訊頁
+      navigate("/", { replace: true });
+    },
+    onError: (error) => {
+      // 開發 debug 錯誤訊息
+      console.error(error);
+
+      // 用戶已存在， UI 提示錯誤訊息
+      if (error.message === `User already registered`) {
+        toast.error(`註冊失敗，用戶已存在`);
+        return;
+      }
+
+      // 其他錯誤，UI 提示訊息
+      toast.error(`註冊失敗`);
+    },
+  });
+
+  return { signUp, isLoading };
+}

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -39,3 +39,13 @@ export async function apiSignUp({ username, email, password }) {
     throw new Error(error.message);
   }
 }
+
+export async function apiSignOut() {
+  try {
+    const { error } = await supabase.auth.signOut();
+
+    if (error) throw error;
+  } catch (error) {
+    throw new Error(error.message);
+  }
+}

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -15,17 +15,27 @@ export async function apiSignIn({ email, password }) {
   }
 }
 
-// export async function apiSignUp({ email, password }) {
-//   try {
-//     let { data, error } = await supabase.auth.signUp({
-//       email: "someone@email.com",
-//       password: "ZvJSNmuMDODXryWIDpFu",
-//     });
+export async function apiSignUp({ username, email, password }) {
+  const newUser = {
+    email,
+    password,
+    options: {
+      data: {
+        display_name: username,
+        points: 0,
+        transaction_counts: 0,
+        roles: ["users"],
+        avatar_url: "https://fakeimg.pl/200/",
+      },
+    },
+  };
+  try {
+    let { data, error } = await supabase.auth.signUp(newUser);
 
-//     if (error) throw error;
+    if (error) throw error;
 
-//     return data;
-//   } catch (error) {
-//     throw new Error(error.message);
-//   }
-// }
+    return data;
+  } catch (error) {
+    throw new Error(error.message);
+  }
+}

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -1,0 +1,31 @@
+import supabase from "./supabase";
+
+export async function apiSignIn({ email, password }) {
+  try {
+    let { data, error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    if (error) throw error;
+
+    return data;
+  } catch (error) {
+    throw new Error(error.message);
+  }
+}
+
+// export async function apiSignUp({ email, password }) {
+//   try {
+//     let { data, error } = await supabase.auth.signUp({
+//       email: "someone@email.com",
+//       password: "ZvJSNmuMDODXryWIDpFu",
+//     });
+
+//     if (error) throw error;
+
+//     return data;
+//   } catch (error) {
+//     throw new Error(error.message);
+//   }
+// }


### PR DESCRIPTION
### **背景**  
- 新增 **`apiAuth`** 用於處理一般使用者的權限管理，包括 **註冊、登入、登出** 邏輯。  

### **主要修改**  
- **`apiAuth.js`**  
  - 新增 **`apiSignIn`**：處理登入 API 請求  
  - 新增 **`apiSignUp`**：處理一般用戶註冊 API 請求  
  - 新增 **`apiSignOut`**：處理登出 API 請求  

- **新增自訂 Hook**（使用 React Query 處理請求、快取、UI 提示及 Cookie 操作）  
  - **`useSignIn.js`**：負責登入流程  
  - **`useSignUp.js`**：負責註冊流程  
  - **`useSignOut.js`**：負責登出流程  

### **影響範圍**  
- **API 邏輯（`apiAuth.js`）**  
  - 影響 **一般使用者的註冊、登入、登出 API 請求**  

- **`useSignIn.js`**（登入）  
  - 影響登入成功或失敗後的行為， 快取登入用戶資訊 、UI 訊息提示、cookies 存入、重新定向頁面

- **`useSignUp.js`**（註冊）  
  - 影響註冊成功或失敗後的行為， 快取登入用戶資訊 、UI 訊息提示、cookies 存入、重新定向頁面

- **`useSignOut.js`**（登出）  
  - 影響登出成功或失敗後的行為， 清除快取 、UI 訊息提示、刪除 Cookie、重新定向頁面

---

### **測試方式**  
- **註冊 (`apiSignUp`)**  
    - [ ] 測試 **新用戶註冊成功** 時，是否能夠儲存用戶資訊、顯示成功訊息、重新定向回首頁
    - [ ] 測試 **註冊失敗** 時，是否能顯示錯誤提示  

- **登入 (`apiSignIn`)**  
    - [ ] 測試 **登入成功** 時，是否能儲存用戶資訊、顯示成功訊息、重新定向回首頁
    - [ ] 測試 **登入失敗** 時，是否能顯示錯誤提示  

- **登出 (`apiSignOut`)**  
    - [ ] 測試 **登出成功** 時，是否會刪除 Cookie 、顯示成功訊息、重新定向回首頁 
    - [ ] 測試 **登出失敗** 時，是否能顯示錯誤提示  

--- 

**Issue**: #21