### PR TITLE
Feature: 5-3、5-4、5-7 讀取紙箱API 拆分

### DIFF
--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -1,12 +1,13 @@
 import {
   apiGetBoxesForSelling,
+  apiGetBoxesForAdminManaging,
   apiGetBoxesForScraping,
 } from "@/services/apiBoxes";
 import { useQuery } from "@tanstack/react-query";
 /**
- * 自訂 Hook：使用 React Query 來取得紙箱資料
+ * 自訂 Hook：使用 React Query 來取得紙箱狀態為可認領的紙箱資料
  *
- * 使用 `useQuery` 來向 API 請求紙箱資料，並處理資料加載與錯誤狀態。
+ * 使用 `useQuery` 來向 API 請求紙箱狀態為可認領的紙箱資料，並處理資料加載與錯誤狀態。
  *
  * @returns {Object} 返回包含三個屬性的物件：
  *   - `boxes` {Array|null} - 紙箱資料陣列，若尚未請求或發生錯誤則為 `null`
@@ -25,11 +26,33 @@ export function useBoxesForSelling() {
 
   return { boxes, isLoadingBoxes, boxesError };
 }
+/**
+ * 自訂 Hook：使用 React Query 來取得 5-3 可認領紙箱列表的紙箱資料
+ *
+ * 使用 `useQuery` 來向 API 請求可認領紙箱列表的紙箱資料，並處理資料加載與錯誤狀態。
+ *
+ * @returns {Object} 返回包含三個屬性的物件：
+ *   - `boxes` {Array|null} - 紙箱資料陣列，若尚未請求或發生錯誤則為 `null`
+ *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
+ *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
+ */
+export function useBoxesForAdminManaging() {
+  const {
+    data: boxes,
+    isLoading: isLoadingBoxes,
+    error: boxesError,
+  } = useQuery({
+    queryKey: ["boxes", "managing"],
+    queryFn: apiGetBoxesForAdminManaging,
+  });
+
+  return { boxes, isLoadingBoxes, boxesError };
+}
 
 /**
- * 自訂 Hook：使用 React Query 來取得紙箱資料
+ * 自訂 Hook：使用 React Query 來取得 5-4 待回收紙箱列表的紙箱資料
  *
- * 使用 `useQuery` 來向 API 請求紙箱資料，並處理資料加載與錯誤狀態。
+ * 使用 `useQuery` 來向 API 請求 5-4 待回收紙箱列表的紙箱資料，並處理資料加載與錯誤狀態。
  *
  * @returns {Object} 返回包含三個屬性的物件：
  *   - `boxes` {Array|null} - 紙箱資料陣列，若尚未請求或發生錯誤則為 `null`

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -1,9 +1,9 @@
 import supabase from "./supabase";
 
 /**
- * 從 Supabase 取得所有紙箱資料
+ * 從 Supabase 取得紙箱狀態為可認領的紙箱資料
  *
- * 該函式向 Supabase 的 `boxes` 表格請求可認領紙箱列表的資料，並處理錯誤。
+ * 該函式向 Supabase 的 `boxes` 表格請求紙箱狀態為可認領的資料，並處理錯誤。
  *
  * @async
  * @function apiGetBoxesForSelling
@@ -11,6 +11,34 @@ import supabase from "./supabase";
  * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
  */
 export async function apiGetBoxesForSelling() {
+  try {
+    let { data: boxes, error } = await supabase
+      .from("boxes")
+      .select("*")
+      .in("status", ["可認領"]);
+
+    if (error) throw error;
+
+    return boxes;
+  } catch (error) {
+    // supabase 錯誤內容
+    console.error(error);
+    // UI 顯示的錯誤內容
+    throw new Error("無法取得 boxes 資料，請稍後再試");
+  }
+}
+
+/**
+ * 從 Supabase 取得 5-3 可認領紙箱列表的紙箱資料
+ *
+ * 該函式向 Supabase 的 `boxes` 表格請求 5-3 可認領紙箱列表的資料，並處理錯誤。
+ *
+ * @async
+ * @function apiGetBoxesForAdminManaging
+ * @returns {Promise<Array>} 紙箱資料陣列，若請求成功返回資料，若失敗則會拋出錯誤
+ * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
+ */
+export async function apiGetBoxesForAdminManaging() {
   try {
     let { data: boxes, error } = await supabase
       .from("boxes")
@@ -29,9 +57,9 @@ export async function apiGetBoxesForSelling() {
 }
 
 /**
- * 從 Supabase 取得所有紙箱資料
+ * 從 Supabase 取得 5-4 待回收紙箱列表的紙箱資料
  *
- * 該函式向 Supabase 的 `boxes` 表格請求待回收紙箱列表的資料，並處理錯誤。
+ * 該函式向 Supabase 的 `boxes` 表格請求 5-4 待回收紙箱列表的資料，並處理錯誤。
  *
  * @async
  * @function apiGetBoxesForScraping
@@ -53,5 +81,35 @@ export async function apiGetBoxesForScraping() {
     console.error(error);
     // UI 顯示的錯誤內容
     throw new Error("無法取得 boxes 資料，請稍後再試");
+  }
+}
+
+/**
+ * 從 Supabase 更新單一筆紙箱資料
+ *
+ * 該函式向 Supabase 的 `boxes` 表格更新單一筆的紙箱資料，並處理錯誤。
+ *
+ * @async
+ * @function apiUpdateBox
+ * @returns {Promise<Array>} 紙箱資料陣列，若請求成功返回資料，若失敗則會拋出錯誤
+ * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
+ */
+
+export async function apiUpdateBox({ row, values }) {
+  try {
+    const { data: box, error } = await supabase
+      .from("boxes")
+      .update({ ...values, updated_at: Date.now() })
+      .eq("id", row.id)
+      .select();
+
+    if (error) throw error;
+
+    return box;
+  } catch (error) {
+    // supabase 錯誤內容
+    console.error(error);
+    // UI 顯示的錯誤內容
+    throw new Error("無法更新 boxes 資料，請稍後再試");
   }
 }


### PR DESCRIPTION
### **背景**
- 實作 API 根據紙箱狀態篩選紙箱資料，並封裝成不同 API 以供不同列表顯示。 

### **主要修改**
- 調整 `apiBoxes.js` 
    - 新增 篩選紙箱狀態`status`為 `["可認領"]` 並讀取紙箱資料 邏輯

- 調整 `useBoxes.js` 自定義 Hook 透過 React Query 取得紙箱資料
  -  `useBoxesForSelling` : 讀取紙箱資料API（5-7 回收站點管理者後台 - 售出紙箱流程 ），querykey 為 `["boxes", "selling"]`
  -  `useBoxesForAdminManaging` : 讀取紙箱資料API（5-3  可認領紙箱列表），querykey 為 `["boxes", "managing"]`
  -  `useBoxesForScraping` : 讀取紙箱資料API（5-4  待回收紙箱列表），querykey 為 `["boxes", "scraping"]`
  
### **測試方式**
- [ ] 呼叫 `useBoxesForSelling` 是否能取得紙箱狀態為 `["可認領"]` 紙箱資料？  

issue #10 