### PR TITLE
feat: 完成 5-2-2 可回收空位數（站點管理者）

### DIFF
--- a/src/components/AdminInfo.jsx
+++ b/src/components/AdminInfo.jsx
@@ -1,37 +1,98 @@
 import { Button } from "./ui/button";
-import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
+
 import { useStation } from "@/hooks/useStation";
+import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
+import { useUpdateRecyclableBoxes } from "@/hooks/useUpdateRecyclableBoxes";
 import { getTimestamp } from "@/utils/helpers";
+
+import Spinner from "./Spinner";
 
 function AdminInfo() {
   const { station, isLoadingStation, stationError } = useStation(1);
   const { updateStation, isUpdating } = useUpdateStationInfo();
+  const { updateRecyclableBoxes, isLoading } = useUpdateRecyclableBoxes();
+
+  if (isLoadingStation) return <Spinner />;
+
+  const {
+    id,
+    station_name,
+    address,
+    phone,
+    image_url,
+    station_daily_hours,
+    pending_boxes_xl,
+    pending_boxes_l,
+    pending_boxes_m,
+    pending_boxes_s,
+    available_slots,
+  } = station;
 
   return (
     <div>
       5-2 回收站點回收資訊總覽
-      <Button
-        onClick={() =>
-          updateStation({
-            id: 1,
-            address: "新北市三重區大同南路152號1樓",
-            phone: "+886-2-2975970",
-            updated_at: getTimestamp(),
-            station_daily_hours: [
-              {
-                id: 3,
-                open_time: `07:00:00+00`,
-                close_time: `21:00:00+00`,
-                updated_at: getTimestamp(),
-              },
-            ],
-          })
-        }
-        disabled={isUpdating}
-      >
-        Update station
-      </Button>
-      {station && <p>{station?.station_name}</p>}
+      <div className="my-6">
+        <Button
+          onClick={() =>
+            updateStation({
+              id: 1,
+              address: "新北市三重區大同南路152號1樓",
+              phone: "+886-2-2975970",
+              updated_at: getTimestamp(),
+              station_daily_hours: [
+                {
+                  id: 7,
+                  open_time: `05:00:00+00`,
+                  close_time: `21:00:00+00`,
+                  updated_at: getTimestamp(),
+                },
+              ],
+            })
+          }
+          disabled={isUpdating}
+        >
+          更新站點基本資訊
+        </Button>
+        <Button
+          className="ms-4"
+          onClick={() => {
+            updateRecyclableBoxes({
+              stationId: station.id,
+              xlCounts: 1,
+              lCounts: 0,
+              mCounts: 6,
+              sCounts: 10,
+            });
+          }}
+        >
+          更新站點可回收紙箱數量
+        </Button>
+      </div>
+      <div>
+        <p>店名：{station_name}</p>
+        <p>地址：{address}</p>
+        <p>電話：{phone}</p>
+        <p>
+          營業時間：
+          <ul className="ms-5 list-disc ps-5">
+            {station_daily_hours.map((el) => (
+              <li key={el.id}>
+                id：{el.id} / 星期：
+                {el.day_of_week === 0 ? 7 : el.day_of_week}：{el.open_time}
+              </li>
+            ))}
+          </ul>
+        </p>
+        <p>可認領紙箱數量 XL：{pending_boxes_xl}</p>
+        <p>可認領紙箱數量 L：{pending_boxes_l}</p>
+        <p>可認領紙箱數量 M：{pending_boxes_m}</p>
+        <p>可認領紙箱數量 S：{pending_boxes_s}</p>
+        <p>可回收紙箱數量 XL：{available_slots.XL}</p>
+        <p>可回收紙箱數量 L：{available_slots.L}</p>
+        <p>可回收紙箱數量 M：{available_slots.M}</p>
+        <p>可回收紙箱數量 S：{available_slots.S}</p>
+      </div>
+      <div className="my-4"></div>
     </div>
   );
 }

--- a/src/components/AdminInfo.jsx
+++ b/src/components/AdminInfo.jsx
@@ -2,7 +2,7 @@ import { Button } from "./ui/button";
 
 import { useStation } from "@/hooks/useStation";
 import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
-import { useUpdateRecyclableBoxes } from "@/hooks/useUpdateRecyclableBoxes";
+import { useUpdateAvailableSlots } from "@/hooks/useUpdateAvailableSlots";
 import { getTimestamp } from "@/utils/helpers";
 
 import Spinner from "./Spinner";
@@ -10,7 +10,7 @@ import Spinner from "./Spinner";
 function AdminInfo() {
   const { station, isLoadingStation, stationError } = useStation(1);
   const { updateStation, isUpdating } = useUpdateStationInfo();
-  const { updateRecyclableBoxes, isLoading } = useUpdateRecyclableBoxes();
+  const { updateAvailableSlots, isLoading } = useUpdateAvailableSlots();
 
   if (isLoadingStation) return <Spinner />;
 
@@ -56,11 +56,11 @@ function AdminInfo() {
         <Button
           className="ms-4"
           onClick={() => {
-            updateRecyclableBoxes({
+            updateAvailableSlots({
               stationId: station.id,
-              xlCounts: 1,
+              xlCounts: 0,
               lCounts: 0,
-              mCounts: 6,
+              mCounts: 0,
               sCounts: 10,
             });
           }}
@@ -72,7 +72,7 @@ function AdminInfo() {
         <p>店名：{station_name}</p>
         <p>地址：{address}</p>
         <p>電話：{phone}</p>
-        <p>
+        <div>
           營業時間：
           <ul className="ms-5 list-disc ps-5">
             {station_daily_hours.map((el) => (
@@ -82,17 +82,16 @@ function AdminInfo() {
               </li>
             ))}
           </ul>
-        </p>
+        </div>
         <p>可認領紙箱數量 XL：{pending_boxes_xl}</p>
         <p>可認領紙箱數量 L：{pending_boxes_l}</p>
         <p>可認領紙箱數量 M：{pending_boxes_m}</p>
         <p>可認領紙箱數量 S：{pending_boxes_s}</p>
-        <p>可回收紙箱數量 XL：{available_slots.XL}</p>
-        <p>可回收紙箱數量 L：{available_slots.L}</p>
-        <p>可回收紙箱數量 M：{available_slots.M}</p>
-        <p>可回收紙箱數量 S：{available_slots.S}</p>
+        <p>可回收紙箱空位數 XL：{available_slots.XL}</p>
+        <p>可回收紙箱空位數 L：{available_slots.L}</p>
+        <p>可回收紙箱空位數 M：{available_slots.M}</p>
+        <p>可回收紙箱空位數 S：{available_slots.S}</p>
       </div>
-      <div className="my-4"></div>
     </div>
   );
 }

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,6 +1,13 @@
 import { useState, useEffect, useRef } from "react";
-import { MapContainer, TileLayer, Marker, Popup, useMap, useMapEvent, } from "react-leaflet";
-import { NavLink } from 'react-router-dom';
+import {
+  MapContainer,
+  TileLayer,
+  Marker,
+  Popup,
+  useMap,
+  useMapEvent,
+} from "react-leaflet";
+import { NavLink } from "react-router-dom";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
 
@@ -26,7 +33,7 @@ const UserLocation = () => {
         },
         (error) => {
           console.error("無法獲取位置：", error);
-        }
+        },
       );
     } else {
       console.error("瀏覽器不支援地理位置功能！");
@@ -42,8 +49,8 @@ function Map() {
   const { station, isLoadingStation, stationError } = useStation(clickedId); //所選擇的站點詳細資訊
 
   const [isAllOpenTime, setIsAllOpenTime] = useState(false); //開啟詳細營業時間
-  const [isBoxSize, setIsBoxSize] = useState(false);//開啟查看紙箱尺寸
-  const [isSideBar, setIsSideBar] = useState(false);//開啟SideBar
+  const [isBoxSize, setIsBoxSize] = useState(false); //開啟查看紙箱尺寸
+  const [isSideBar, setIsSideBar] = useState(false); //開啟SideBar
 
   if (isLoadingStations) return <Spinner />;
   if (stationsError) return <ErrorMessage error={stationsError} />;
@@ -51,16 +58,26 @@ function Map() {
   // 資料處理
   // 計算紙箱數量
   const countRecyclableBoxes = (station) => {
-    return station.recyclable_boxes.XL + station.recyclable_boxes.L + station.recyclable_boxes.M + station.recyclable_boxes.S
-  }
+    return (
+      station.available_slots.XL +
+      station.available_slots.L +
+      station.available_slots.M +
+      station.available_slots.S
+    );
+  };
 
   const countPendingBoxes = (station) => {
-    return station.pending_boxes_xl + station.pending_boxes_l + station.pending_boxes_m + station.pending_boxes_s
-  }
+    return (
+      station.pending_boxes_xl +
+      station.pending_boxes_l +
+      station.pending_boxes_m +
+      station.pending_boxes_s
+    );
+  };
   // 電話國際碼轉換市碼
   const formatPhoneNumber = (phone) => {
-    return phone.replace(/^\+886-/, "0").replace(/#$/, "");
-  }
+    return phone?.replace(/^\+886-/, "0").replace(/#$/, "");
+  };
   // 取得一週的營業時間
   const formatOpenTime = (station_daily_hours) => {
     return station_daily_hours.map((item, index) => {
@@ -68,39 +85,37 @@ function Map() {
       const closeTime = item.close_time.replace(/^(\d{2}:\d{2}):\d{2}.*/, "$1");
 
       if (index === 0) {
-        return <li key={index}>{`星期日 ${openTime}-${closeTime}`}</li>
+        return <li key={index}>{`星期日 ${openTime}-${closeTime}`}</li>;
       } else if (index === 1) {
-        return <li key={index}>{`星期一 ${openTime}-${closeTime}`}</li>
+        return <li key={index}>{`星期一 ${openTime}-${closeTime}`}</li>;
       } else if (index === 2) {
-        return <li key={index}>{`星期二 ${openTime}-${closeTime}`}</li>
+        return <li key={index}>{`星期二 ${openTime}-${closeTime}`}</li>;
       } else if (index === 3) {
-        return <li key={index}>{`星期三 ${openTime}-${closeTime}`}</li>
+        return <li key={index}>{`星期三 ${openTime}-${closeTime}`}</li>;
       } else if (index === 4) {
-        return <li key={index}>{`星期四 ${openTime}-${closeTime}`}</li>
+        return <li key={index}>{`星期四 ${openTime}-${closeTime}`}</li>;
       } else if (index === 5) {
-        return <li key={index}>{`星期五 ${openTime}-${closeTime}`}</li>
+        return <li key={index}>{`星期五 ${openTime}-${closeTime}`}</li>;
       } else {
-        return <li key={index}>{`星期六 ${openTime}-${closeTime}`}</li>
+        return <li key={index}>{`星期六 ${openTime}-${closeTime}`}</li>;
       }
-
-    })
-  }
+    });
+  };
   // 取得本日營業時間
   const getTodayOpenTime = (station_daily_hours) => {
     const today = new Date().getDay();
-    let todayOpenTime = '';
+    let todayOpenTime = "";
     station_daily_hours.forEach((item, index) => {
       const openTime = item.open_time.replace(/^(\d{2}:\d{2}):\d{2}.*/, "$1");
       const closeTime = item.close_time.replace(/^(\d{2}:\d{2}):\d{2}.*/, "$1");
 
       if (today === index) {
-        todayOpenTime = `${openTime}-${closeTime}`
+        todayOpenTime = `${openTime}-${closeTime}`;
       }
-    })
+    });
 
     return todayOpenTime;
-
-  }
+  };
   // 設定icon
   const customIcon = new L.Icon({
     iconUrl: mapMark,
@@ -111,162 +126,224 @@ function Map() {
     <>
       <MapNav />
 
-      <div className="mx-auto flex flex-col md:flex-row justify-between relative" style={{ height: '700px', width: "100%" }}>
+      <div
+        className="relative mx-auto flex flex-col justify-between md:flex-row"
+        style={{ height: "700px", width: "100%" }}
+      >
         {/* 側邊欄 */}
-        {isSideBar ? <div className="w-[486px] overflow-auto flex-shrink-0">
-          {station ? (
-            <div>
-              <img src={station.image_url} alt={station.station_name} className="object-cover w-full" />
-              <div className="p-[24px]" >
-                <h5 className="mb-[12px]">{station.station_name}</h5>
-                <h5 className="text-base flex gap-[8px] mb-[12px]">
-                  {countRecyclableBoxes(station) ? <span className="rounded-full bg-main-200 py-[4px] px-[12px] fs-7">可認領</span> : <></>}
-                  {countPendingBoxes(station) ? <span className="rounded-full bg-second-200 py-[4px] px-[12px] fs-7">可認領</span> : <></>}
-                </h5>
+        {isSideBar ? (
+          <div className="w-[486px] flex-shrink-0 overflow-auto">
+            {station ? (
+              <div>
+                <img
+                  src={station.image_url}
+                  alt={station.station_name}
+                  className="w-full object-cover"
+                />
+                <div className="p-[24px]">
+                  <h5 className="mb-[12px]">{station.station_name}</h5>
+                  <h5 className="mb-[12px] flex gap-[8px] text-base">
+                    {countRecyclableBoxes(station) ? (
+                      <span className="fs-7 rounded-full bg-main-200 px-[12px] py-[4px]">
+                        可回收
+                      </span>
+                    ) : (
+                      <></>
+                    )}
+                    {countPendingBoxes(station) ? (
+                      <span className="fs-7 rounded-full bg-second-200 px-[12px] py-[4px]">
+                        可認領
+                      </span>
+                    ) : (
+                      <></>
+                    )}
+                  </h5>
 
-                <ul className="fs-6 text-[#6F6F6F] flex flex-col gap-[12px] mb-[12px]">
-                  <li className="flex gap-[8px] items-start justify-start"><span className="material-symbols-outlined">location_on</span>{`地址:${station.address}`}</li>
-                  <li className="flex gap-[8px] items-start justify-start"><span className="material-symbols-outlined">call</span>{`電話:${formatPhoneNumber(station.phone)}`}</li>
-                  <li className="flex gap-[8px] items-start justify-start">
-                    <span className="material-symbols-outlined">schedule</span>
-                    <p>{`營業時間:${getTodayOpenTime(station.station_daily_hours)}`}</p>
-                    <button onClick={() => setIsAllOpenTime(!isAllOpenTime)}>
-                      {isAllOpenTime ? <span className="material-symbols-outlined">keyboard_arrow_up</span> : <span className="material-symbols-outlined">keyboard_arrow_down</span>}
-                    </button>
-                  </li>
-                  {isAllOpenTime && <ul className="flex flex-col items-center w-full gap-[8px]">
-                    {formatOpenTime(station.station_daily_hours)}
-                  </ul>}
-                </ul>
-
-
-                <div className="p-[16px] border border-solid border-[#B7B7B7] rounded-lg mb-[12px]">
-                  <h6 className="mb-[12px]">回收認領資訊</h6>
-
-                  <div className="flex gap-[25px] justify-center mb-[12px]">
-                    {/* 可回收 */}
-                    <div>
-                      <p className="w-full text-center text-main-600 bg-main-100 rounded-lg py-[4px] mb-[8px]">可回收紙箱</p>
-                      <div className="flex gap-[8px]">
-                        <div className="text-main-600 bg-main-100 rounded-lg flex flex-col items-center p-[8px]">
-                          <h4>{station.recyclable_boxes.S}</h4>
-                          <p>S</p>
-                        </div>
-                        <div className="text-main-600 bg-main-100 rounded-lg flex flex-col items-center p-[8px]">
-                          <h4>{station.recyclable_boxes.M}</h4>
-                          <p>M</p>
-                        </div>
-                        <div className="text-main-600 bg-main-100 rounded-lg flex flex-col items-center p-[8px]">
-                          <h4>{station.recyclable_boxes.L}</h4>
-                          <p>L</p>
-                        </div>
-                        <div className="text-main-600 bg-main-100 rounded-lg flex flex-col items-center p-[8px]">
-                          <h4>{station.recyclable_boxes.XL}</h4>
-                          <p>XL</p>
-                        </div>
-
-                      </div>
-                    </div>
-                    {/* 可認領 */}
-                    <div>
-                      <p className="w-full text-center text-second-600 bg-second-100 rounded-lg py-[4px] mb-[8px]">可認領紙箱</p>
-                      <div className="flex gap-[8px]">
-                        <div className="text-second-600 bg-second-100 rounded-lg flex flex-col items-center p-[8px]">
-                          <h4>{station.pending_boxes_s}</h4>
-                          <p>S</p>
-                        </div>
-                        <div className="text-second-600 bg-second-100 rounded-lg flex flex-col items-center p-[8px]">
-                          <h4>{station.pending_boxes_m}</h4>
-                          <p>M</p>
-                        </div>
-                        <div className="text-second-600 bg-second-100 rounded-lg flex flex-col items-center p-[8px]">
-                          <h4>{station.pending_boxes_l}</h4>
-                          <p>L</p>
-                        </div>
-                        <div className="text-second-600 bg-second-100 rounded-lg flex flex-col items-center p-[8px]">
-                          <h4>{station.pending_boxes_xl}</h4>
-                          <p>XL</p>
-                        </div>
-
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="border-t border-[#B7B7B7] pt-[12px]">
-                    <div className="flex justify-between">
-                      <p>查看紙箱尺寸</p>
-                      <button onClick={() => setIsBoxSize(!isBoxSize)}>
-                        {isBoxSize ? <span className="material-symbols-outlined">keyboard_arrow_up</span> : <span className="material-symbols-outlined">keyboard_arrow_down</span>}
+                  <ul className="fs-6 mb-[12px] flex flex-col gap-[12px] text-[#6F6F6F]">
+                    <li className="flex items-start justify-start gap-[8px]">
+                      <span className="material-symbols-outlined">
+                        location_on
+                      </span>
+                      {`地址:${station.address}`}
+                    </li>
+                    <li className="flex items-start justify-start gap-[8px]">
+                      <span className="material-symbols-outlined">call</span>
+                      {`電話:${formatPhoneNumber(station.phone)}`}
+                    </li>
+                    <li className="flex items-start justify-start gap-[8px]">
+                      <span className="material-symbols-outlined">
+                        schedule
+                      </span>
+                      <p>{`營業時間:${getTodayOpenTime(station.station_daily_hours)}`}</p>
+                      <button onClick={() => setIsAllOpenTime(!isAllOpenTime)}>
+                        {isAllOpenTime ? (
+                          <span className="material-symbols-outlined">
+                            keyboard_arrow_up
+                          </span>
+                        ) : (
+                          <span className="material-symbols-outlined">
+                            keyboard_arrow_down
+                          </span>
+                        )}
                       </button>
+                    </li>
+                    {isAllOpenTime && (
+                      <ul className="flex w-full flex-col items-center gap-[8px]">
+                        {formatOpenTime(station.station_daily_hours)}
+                      </ul>
+                    )}
+                  </ul>
+
+                  <div className="mb-[12px] rounded-lg border border-solid border-[#B7B7B7] p-[16px]">
+                    <h6 className="mb-[12px]">回收認領資訊</h6>
+
+                    <div className="mb-[12px] flex justify-center gap-[25px]">
+                      {/* 可回收 */}
+                      <div>
+                        <p className="mb-[8px] w-full rounded-lg bg-main-100 py-[4px] text-center text-main-600">
+                          可回收紙箱
+                        </p>
+                        <div className="flex gap-[8px]">
+                          <div className="flex flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                            <h4>{station.available_slots.S}</h4>
+                            <p>S</p>
+                          </div>
+                          <div className="flex flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                            <h4>{station.available_slots.M}</h4>
+                            <p>M</p>
+                          </div>
+                          <div className="flex flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                            <h4>{station.available_slots.L}</h4>
+                            <p>L</p>
+                          </div>
+                          <div className="flex flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                            <h4>{station.available_slots.XL}</h4>
+                            <p>XL</p>
+                          </div>
+                        </div>
+                      </div>
+                      {/* 可認領 */}
+                      <div>
+                        <p className="text-second-600 mb-[8px] w-full rounded-lg bg-second-100 py-[4px] text-center">
+                          可認領紙箱
+                        </p>
+                        <div className="flex gap-[8px]">
+                          <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[8px]">
+                            <h4>{station.pending_boxes_s}</h4>
+                            <p>S</p>
+                          </div>
+                          <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[8px]">
+                            <h4>{station.pending_boxes_m}</h4>
+                            <p>M</p>
+                          </div>
+                          <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[8px]">
+                            <h4>{station.pending_boxes_l}</h4>
+                            <p>L</p>
+                          </div>
+                          <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[8px]">
+                            <h4>{station.pending_boxes_xl}</h4>
+                            <p>XL</p>
+                          </div>
+                        </div>
+                      </div>
                     </div>
-                    {isBoxSize ? (
-                      <ul className="text-[#6F6F6F] list-disc list-inside">
-                        <li>小紙箱：總長 50 公分以下</li>
-                        <li>中紙箱：總長 50 ~ 120 公分</li>
-                        <li>大紙箱：總長 120 公分以上</li>
-                      </ul>) : <></>
-                    }
 
-
+                    <div className="border-t border-[#B7B7B7] pt-[12px]">
+                      <div className="flex justify-between">
+                        <p>查看紙箱尺寸</p>
+                        <button onClick={() => setIsBoxSize(!isBoxSize)}>
+                          {isBoxSize ? (
+                            <span className="material-symbols-outlined">
+                              keyboard_arrow_up
+                            </span>
+                          ) : (
+                            <span className="material-symbols-outlined">
+                              keyboard_arrow_down
+                            </span>
+                          )}
+                        </button>
+                      </div>
+                      {isBoxSize ? (
+                        <ul className="list-inside list-disc text-[#6F6F6F]">
+                          <li>小紙箱：總長 50 公分以下</li>
+                          <li>中紙箱：總長 50 ~ 120 公分</li>
+                          <li>大紙箱：總長 120 公分以上</li>
+                        </ul>
+                      ) : (
+                        <></>
+                      )}
+                    </div>
                   </div>
+                  <NavLink className="btn" to={`/map/${station.id}`}>
+                    查看更多
+                  </NavLink>
                 </div>
-                <NavLink className="btn" to={`/map/${station.id}`}>查看更多</NavLink>
-
               </div>
-            </div>
-          ) : '請選擇站點'}
-
-        </div> : <></>}
-
-
+            ) : (
+              "請選擇站點"
+            )}
+          </div>
+        ) : (
+          <></>
+        )}
 
         {/* 地圖 */}
-        <MapContainer className="relative z-0"
+        <MapContainer
+          className="relative z-0"
           center={[stations[0].latitude, stations[0].longitude]} // 預設第一個站點
           zoom={15}
-          style={{ height: '100%', width: "100%" }}
+          style={{ height: "100%", width: "100%" }}
         >
           {/* 地圖圖層 */}
           <TileLayer
             url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
-            attribution='Positron'
+            attribution="Positron"
           />
 
           {/* 地圖上的標記 */}
-          {
-            stations.map(item => (
-              <Marker icon={customIcon} position={[item.latitude, item.longitude]} key={item.id} eventHandlers={{
+          {stations.map((item) => (
+            <Marker
+              icon={customIcon}
+              position={[item.latitude, item.longitude]}
+              key={item.id}
+              eventHandlers={{
                 click: () => {
                   setClickedId(item.id); // 設定選中的站點
                 },
-              }}>
-                <Popup>
-                  {station ?
-                    (<div>
-                      <h6 className='font-semibold text-start mb-[12px]'>{station.station_name}</h6>
-                      <div className="flex gap-[8px] justify-center">
-                        <span className="bg-main-200 py-[4px] px-[12px] rounded-full fs-7">{`可回收${countRecyclableBoxes(station)}個`}</span>
-                        <span className="bg-second-200 py-[4px] px-[12px] rounded-full fs-7">{`可認領${countPendingBoxes(station)}個`}</span>
-                      </div>
-                      <p className="mb-[12px]">{station.address}</p>
-                      <Button className="btn">查看更多</Button>
+              }}
+            >
+              <Popup>
+                {station ? (
+                  <div>
+                    <h6 className="mb-[12px] text-start font-semibold">
+                      {station.station_name}
+                    </h6>
+                    <div className="flex justify-center gap-[8px]">
+                      <span className="fs-7 rounded-full bg-main-200 px-[12px] py-[4px]">{`可回收${countRecyclableBoxes(station)}個`}</span>
+                      <span className="fs-7 rounded-full bg-second-200 px-[12px] py-[4px]">{`可認領${countPendingBoxes(station)}個`}</span>
                     </div>
-                    ) : ''}
-
-                </Popup>
-              </Marker>
-            ))
-          }
+                    <p className="mb-[12px]">{station.address}</p>
+                    <Button className="btn">查看更多</Button>
+                  </div>
+                ) : (
+                  ""
+                )}
+              </Popup>
+            </Marker>
+          ))}
 
           <UserLocation />
 
           {/* 側邊欄開關 */}
-          <button className="absolute top-[273px] left-[0px] w-[40px] h-[72px] z-[999999999] bg-white border-t border-e border-b rounded-r-lg" onClick={() => setIsSideBar(!isSideBar)}>
-            {isSideBar ? <span className="material-symbols-outlined">
-              arrow_back_ios
-            </span> : <span className="material-symbols-outlined">
-              chevron_right
-            </span>}
+          <button
+            className="absolute left-[0px] top-[273px] z-[999999999] h-[72px] w-[40px] rounded-r-lg border-b border-e border-t bg-white"
+            onClick={() => setIsSideBar(!isSideBar)}
+          >
+            {isSideBar ? (
+              <span className="material-symbols-outlined">arrow_back_ios</span>
+            ) : (
+              <span className="material-symbols-outlined">chevron_right</span>
+            )}
           </button>
         </MapContainer>
       </div>

--- a/src/hooks/useUpdateAvailableSlots.js
+++ b/src/hooks/useUpdateAvailableSlots.js
@@ -1,13 +1,13 @@
-import { apiUpdateRecyclableBoxes } from "@/services/apiStations";
+import { apiUpdateAvailableSlots } from "@/services/apiStations";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 
-export function useUpdateRecyclableBoxes() {
+export function useUpdateAvailableSlots() {
   const queryClient = useQueryClient();
 
-  const { mutate: updateRecyclableBoxes, isPending: isLoading } = useMutation({
-    mutationKey: ["updateRecyclableBoxes"],
-    mutationFn: apiUpdateRecyclableBoxes,
+  const { mutate: updateAvailableSlots, isPending: isLoading } = useMutation({
+    mutationKey: ["updateAvailableSlots"],
+    mutationFn: apiUpdateAvailableSlots,
     onSuccess: (station) => {
       toast.success(`成功更新「可回收紙箱數量」`);
       queryClient.invalidateQueries({ queryKey: ["station", station.id] });
@@ -16,5 +16,5 @@ export function useUpdateRecyclableBoxes() {
       toast.error(`更新「可回收紙箱數量」失敗`);
     },
   });
-  return { updateRecyclableBoxes, isLoading };
+  return { updateAvailableSlots, isLoading };
 }

--- a/src/hooks/useUpdateRecyclableBoxes.js
+++ b/src/hooks/useUpdateRecyclableBoxes.js
@@ -1,0 +1,20 @@
+import { apiUpdateRecyclableBoxes } from "@/services/apiStations";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+
+export function useUpdateRecyclableBoxes() {
+  const queryClient = useQueryClient();
+
+  const { mutate: updateRecyclableBoxes, isPending: isLoading } = useMutation({
+    mutationKey: ["updateRecyclableBoxes"],
+    mutationFn: apiUpdateRecyclableBoxes,
+    onSuccess: (station) => {
+      toast.success(`成功更新「可回收紙箱數量」`);
+      queryClient.invalidateQueries({ queryKey: ["station", station.id] });
+    },
+    onError: () => {
+      toast.error(`更新「可回收紙箱數量」失敗`);
+    },
+  });
+  return { updateRecyclableBoxes, isLoading };
+}

--- a/src/pages/StationInfo.jsx
+++ b/src/pages/StationInfo.jsx
@@ -2,28 +2,44 @@ import ErrorMessage from "@/components/ErrorMessage";
 import Header from "@/components/Header";
 import Spinner from "@/components/Spinner";
 import { useStation } from "@/hooks/useStation";
-import { NavLink } from 'react-router-dom';
+import { NavLink } from "react-router-dom";
 import { useState, useEffect, useRef } from "react";
 // Map
-import { MapContainer, TileLayer, Marker, Popup, useMap, useMapEvent, } from "react-leaflet";
+import {
+  MapContainer,
+  TileLayer,
+  Marker,
+  Popup,
+  useMap,
+  useMapEvent,
+} from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
 import mapMark from "../assets/mapMark.png";
 
-
 // 資料處理
 // 計算紙箱數量
 const countRecyclableBoxes = (station) => {
-  return station.recyclable_boxes.XL + station.recyclable_boxes.L + station.recyclable_boxes.M + station.recyclable_boxes.S
-}
+  return (
+    station.available_slots.XL +
+    station.available_slots.L +
+    station.available_slots.M +
+    station.available_slots.S
+  );
+};
 
 const countPendingBoxes = (station) => {
-  return station.pending_boxes_xl + station.pending_boxes_l + station.pending_boxes_m + station.pending_boxes_s
-}
+  return (
+    station.pending_boxes_xl +
+    station.pending_boxes_l +
+    station.pending_boxes_m +
+    station.pending_boxes_s
+  );
+};
 // 電話國際碼轉換市碼
 const formatPhoneNumber = (phone) => {
   return phone.replace(/^\+886-/, "0").replace(/#$/, "");
-}
+};
 // 取得一週的營業時間
 const formatOpenTime = (station_daily_hours) => {
   return station_daily_hours.map((item, index) => {
@@ -31,40 +47,37 @@ const formatOpenTime = (station_daily_hours) => {
     const closeTime = item.close_time.replace(/^(\d{2}:\d{2}):\d{2}.*/, "$1");
 
     if (index === 0) {
-      return <li key={index}>{`星期日 ${openTime}-${closeTime}`}</li>
+      return <li key={index}>{`星期日 ${openTime}-${closeTime}`}</li>;
     } else if (index === 1) {
-      return <li key={index}>{`星期一 ${openTime}-${closeTime}`}</li>
+      return <li key={index}>{`星期一 ${openTime}-${closeTime}`}</li>;
     } else if (index === 2) {
-      return <li key={index}>{`星期二 ${openTime}-${closeTime}`}</li>
+      return <li key={index}>{`星期二 ${openTime}-${closeTime}`}</li>;
     } else if (index === 3) {
-      return <li key={index}>{`星期三 ${openTime}-${closeTime}`}</li>
+      return <li key={index}>{`星期三 ${openTime}-${closeTime}`}</li>;
     } else if (index === 4) {
-      return <li key={index}>{`星期四 ${openTime}-${closeTime}`}</li>
+      return <li key={index}>{`星期四 ${openTime}-${closeTime}`}</li>;
     } else if (index === 5) {
-      return <li key={index}>{`星期五 ${openTime}-${closeTime}`}</li>
+      return <li key={index}>{`星期五 ${openTime}-${closeTime}`}</li>;
     } else {
-      return <li key={index}>{`星期六 ${openTime}-${closeTime}`}</li>
+      return <li key={index}>{`星期六 ${openTime}-${closeTime}`}</li>;
     }
-
-  })
-}
+  });
+};
 // 取得本日營業時間
 const getTodayOpenTime = (station_daily_hours) => {
   const today = new Date().getDay();
-  let todayOpenTime = '';
+  let todayOpenTime = "";
   station_daily_hours.forEach((item, index) => {
     const openTime = item.open_time.replace(/^(\d{2}:\d{2}):\d{2}.*/, "$1");
     const closeTime = item.close_time.replace(/^(\d{2}:\d{2}):\d{2}.*/, "$1");
 
     if (today === index) {
-      todayOpenTime = `${openTime}-${closeTime}`
+      todayOpenTime = `${openTime}-${closeTime}`;
     }
-  })
+  });
 
   return todayOpenTime;
-
-}
-
+};
 
 function StationInfo() {
   const { station, isLoadingStation, stationError } = useStation();
@@ -84,20 +97,46 @@ function StationInfo() {
       <main>
         {/* Section1 */}
         <div className="bg-second-100 py-[40px]">
-          <div className="container mx-auto ">
-            <NavLink to='/map' className='h5 flex items-center gap-[4px] text-[#6F6F6F] mb-[24px]'><span className="material-symbols-outlined">arrow_back</span>返回地圖</NavLink>
+          <div className="container mx-auto">
+            <NavLink
+              to="/map"
+              className="h5 mb-[24px] flex items-center gap-[4px] text-[#6F6F6F]"
+            >
+              <span className="material-symbols-outlined">arrow_back</span>
+              返回地圖
+            </NavLink>
             <div className="flex justify-between">
               {/* 站點資訊 */}
               <div>
                 <h2 className="mb-[24px]">{station.station_name}</h2>
-                <h5 className="text-base flex gap-[8px] mb-[24px]">
-                  {countRecyclableBoxes(station) ? <span className="rounded-full bg-main-200 py-[4px] px-[12px] fs-7">可認領</span> : <></>}
-                  {countPendingBoxes(station) ? <span className="rounded-full bg-second-200 py-[4px] px-[12px] fs-7">可認領</span> : <></>}
+                <h5 className="mb-[24px] flex gap-[8px] text-base">
+                  {countRecyclableBoxes(station) ? (
+                    <span className="fs-7 rounded-full bg-main-200 px-[12px] py-[4px]">
+                      可回收
+                    </span>
+                  ) : (
+                    <></>
+                  )}
+                  {countPendingBoxes(station) ? (
+                    <span className="fs-7 rounded-full bg-second-200 px-[12px] py-[4px]">
+                      可認領
+                    </span>
+                  ) : (
+                    <></>
+                  )}
                 </h5>
-                <ul className="fs-6 text-[#6F6F6F] flex flex-col gap-[12px] mb-[12px]">
-                  <li className="flex gap-[8px] items-start justify-start"><span className="material-symbols-outlined">location_on</span>{`地址:${station.address}`}</li>
-                  <li className="flex gap-[8px] items-start justify-start"><span className="material-symbols-outlined">call</span>{`電話:${formatPhoneNumber(station.phone)}`}</li>
-                  <li className="flex gap-[8px] items-start justify-start">
+                <ul className="fs-6 mb-[12px] flex flex-col gap-[12px] text-[#6F6F6F]">
+                  <li className="flex items-start justify-start gap-[8px]">
+                    <span className="material-symbols-outlined">
+                      location_on
+                    </span>
+                    {`地址:${station.address}`}
+                  </li>
+                  <li className="flex items-start justify-start gap-[8px]">
+                    <span className="material-symbols-outlined">call</span>
+                    {`電話:${formatPhoneNumber(station.phone)}`}
+                  </li>
+                  <li className="flex items-start justify-start gap-[8px]">
                     <span className="material-symbols-outlined">schedule</span>
                     <p>{`營業時間:${getTodayOpenTime(station.station_daily_hours)}`}</p>
                     {/* <button onClick={() => setIsAllOpenTime(!isAllOpenTime)}>
@@ -107,7 +146,7 @@ function StationInfo() {
                   {/* {isAllOpenTime && <ul className="flex flex-col items-center w-full gap-[8px]">
                     {formatOpenTime(station.station_daily_hours)}
                   </ul>} */}
-                  <ul className="flex flex-col items-center w-full gap-[8px]">
+                  <ul className="flex w-full flex-col items-center gap-[8px]">
                     {formatOpenTime(station.station_daily_hours)}
                   </ul>
                 </ul>
@@ -117,91 +156,97 @@ function StationInfo() {
                 <MapContainer
                   center={[station.latitude, station.longitude]}
                   zoom={15}
-                  style={{ height: '100%', width: "100%" }}
+                  style={{ height: "100%", width: "100%" }}
                 >
                   {/* 地圖圖層 */}
                   <TileLayer
                     url="http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
-                    attribution='Positron'
+                    attribution="Positron"
                   />
 
                   {/* 地圖上的標記 */}
-                  <Marker icon={customIcon} position={[station.latitude, station.longitude]}>
+                  <Marker
+                    icon={customIcon}
+                    position={[station.latitude, station.longitude]}
+                  >
                     <Popup>
-                      <a href={`https://www.google.com/maps?q=${station.latitude},${station.longitude}`} target="_blank">
+                      <a
+                        href={`https://www.google.com/maps?q=${station.latitude},${station.longitude}`}
+                        target="_blank"
+                      >
                         在Google地圖中開啟
                       </a>
                     </Popup>
                   </Marker>
-
                 </MapContainer>
               </div>
-
             </div>
           </div>
         </div>
         {/* Section2 */}
         <div className="container mx-auto py-[80px]">
           <h4 className="mb-[24px]">回收認領資訊</h4>
-          <div className="border border-[#B7B7B7] rounded-lg p-[16px]">
-            <div className="flex gap-[25px] justify-center mb-[12px]">
+          <div className="rounded-lg border border-[#B7B7B7] p-[16px]">
+            <div className="mb-[12px] flex justify-center gap-[25px]">
               {/* 可回收 */}
               <div className="w-full">
-                <p className="w-full text-center text-main-600 bg-main-100 rounded-lg py-[4px] mb-[8px]">可回收紙箱</p>
-                <div className="flex gap-[8px] w-full">
-                  <div className="text-main-600 bg-main-100 rounded-lg flex flex-col items-center p-[8px] w-full">
-                    <h4>{station.recyclable_boxes.S}</h4>
+                <p className="mb-[8px] w-full rounded-lg bg-main-100 py-[4px] text-center text-main-600">
+                  可回收紙箱
+                </p>
+                <div className="flex w-full gap-[8px]">
+                  <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                    <h4>{station.available_slots.S}</h4>
                     <p>S</p>
                   </div>
-                  <div className="text-main-600 bg-main-100 rounded-lg flex flex-col items-center p-[8px] w-full">
-                    <h4>{station.recyclable_boxes.M}</h4>
+                  <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                    <h4>{station.available_slots.M}</h4>
                     <p>M</p>
                   </div>
-                  <div className="text-main-600 bg-main-100 rounded-lg flex flex-col items-center p-[8px] w-full">
-                    <h4>{station.recyclable_boxes.L}</h4>
+                  <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                    <h4>{station.available_slots.L}</h4>
                     <p>L</p>
                   </div>
-                  <div className="text-main-600 bg-main-100 rounded-lg flex flex-col items-center p-[8px] w-full">
-                    <h4>{station.recyclable_boxes.XL}</h4>
+                  <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                    <h4>{station.available_slots.XL}</h4>
                     <p>XL</p>
                   </div>
-
                 </div>
               </div>
               {/* 可認領 */}
               <div className="w-full">
-                <p className="w-full text-center text-second-600 bg-second-100 rounded-lg py-[4px] mb-[8px]">可認領紙箱</p>
-                <div className="flex gap-[8px] w-full">
-                  <div className="text-second-600 bg-second-100 rounded-lg flex flex-col items-center p-[8px] w-full">
+                <p className="text-second-600 mb-[8px] w-full rounded-lg bg-second-100 py-[4px] text-center">
+                  可認領紙箱
+                </p>
+                <div className="flex w-full gap-[8px]">
+                  <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[8px]">
                     <h4>{station.pending_boxes_s}</h4>
                     <p>S</p>
                   </div>
-                  <div className="text-second-600 bg-second-100 rounded-lg flex flex-col items-center p-[8px] w-full">
+                  <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[8px]">
                     <h4>{station.pending_boxes_m}</h4>
                     <p>M</p>
                   </div>
-                  <div className="text-second-600 bg-second-100 rounded-lg flex flex-col items-center p-[8px] w-full">
+                  <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[8px]">
                     <h4>{station.pending_boxes_l}</h4>
                     <p>L</p>
                   </div>
-                  <div className="text-second-600 bg-second-100 rounded-lg flex flex-col items-center p-[8px] w-full">
+                  <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[8px]">
                     <h4>{station.pending_boxes_xl}</h4>
                     <p>XL</p>
                   </div>
-
                 </div>
               </div>
             </div>
-            <ul className="text-[#6F6F6F] border-t border-[#B7B7B7] pt-[12px] flex gap-[16px] list-disc list-inside">
-                        <li>小紙箱：總長 50 公分以下</li>
-                        <li>中紙箱：總長 50 ~ 120 公分</li>
-                        <li>大紙箱：總長 120 公分以上</li>
+            <ul className="flex list-inside list-disc gap-[16px] border-t border-[#B7B7B7] pt-[12px] text-[#6F6F6F]">
+              <li>小紙箱：總長 50 公分以下</li>
+              <li>中紙箱：總長 50 ~ 120 公分</li>
+              <li>大紙箱：總長 120 公分以上</li>
             </ul>
           </div>
         </div>
         {/* Section3 */}
         <div className="container mx-auto py-[80px]">
-        <h4 className="mb-[24px]">可認領紙箱列表</h4>
+          <h4 className="mb-[24px]">可認領紙箱列表</h4>
         </div>
       </main>
     </>

--- a/src/services/apiStations.js
+++ b/src/services/apiStations.js
@@ -126,14 +126,13 @@ export async function updateStationHours(hoursData) {
   return { data, error };
 }
 
-export async function apiUpdateRecyclableBoxes({
+export async function apiUpdateAvailableSlots({
   stationId,
   xlCounts,
   lCounts,
   mCounts,
   sCounts,
 }) {
-  console.log({ stationId, xlCounts, lCounts, mCounts, sCounts });
   try {
     const { data, error } = await supabase
       .from("stations")


### PR DESCRIPTION
### 對應使用者故事
- 我可以 編輯站點資訊（地址、連絡電話、營業時間、可回收紙箱、可收容數量），供使用者查看

### 背景

- 新增 站點管理者 編輯「可回收空位數」功能邏輯

---

### 主要修改

- `apiStations.js` 
    - 新增 `apiUpdateAvailableSlots`：處理更新可回收空位數 API 請求
    - 調整 `apiGetStationById` ：回傳資料「station_daily_hours」按照 `day_of_week` 順序排列

-   新增 `useUpdateAvailableSlots` 自訂  Hook（使用 React Query 處理請求、更新緩存資料、成功與失敗的 UI 提示）

### 次要修改
- `AdminInfo.jsx`
    - 簡單串接 useStation & useUpdateRecyclableBoxes ＆ useUpdateStationInfo 測試是否可以順利運行
    
- `Map.jsx` & `StationInfo.jsx` 
    - 原 recyclable_boxes 更名為 available_slots
    - 可回收 tag ，原為可認領，調整文字為 「可回收」

- supabase 欄位：原 `recyclable_boxes` 更名為 `available_slots`

---
### 測試方式

- 呼叫 `updateAvailableSlots` 
   - [ ] 是否可以順利修改可回收紙箱資訊？
   - [ ] 更新成功是否有提示訊息，並自動刷新站點資訊？
   - [ ] 更新失敗是否有提示訊息

---

issue #15 

