### PR TITLE
Feature: 新增 5-3 待認領／自用紙箱列表、5-4 待回收紙箱列表（報廢）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.5",
         "@radix-ui/react-label": "^2.1.2",
+        "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-tabs": "^1.1.3",
         "@supabase/supabase-js": "^2.48.0",
@@ -1186,6 +1187,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
@@ -1809,6 +1816,229 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.6.tgz",
+      "integrity": "sha512-T6ajELxRvTuAMWH0YmRJ1qez+x4/7Nq7QIx7zJ0VK3qaEWdnWpNbEDnmWldG1zBDwqrLy5aLMUWcoGirVj5kMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.2",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.2.tgz",
+      "integrity": "sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.2.tgz",
+      "integrity": "sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz",
+      "integrity": "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.2.tgz",
+      "integrity": "sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.2.tgz",
+      "integrity": "sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.4.tgz",
+      "integrity": "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
@@ -2003,6 +2233,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-rect": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
@@ -2035,6 +2280,52 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.2.tgz",
+      "integrity": "sha512-1SzA4ns2M1aRlvxErqhLHsBHoS5eI5UUcI2awAMgGUp4LoaoWOKYmvqDY2s/tltuPkh3Yk77YF/r3IRj+Amx4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.5",
     "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.3",
     "@supabase/supabase-js": "^2.48.0",

--- a/src/components/form/UpdateBoxForm.jsx
+++ b/src/components/form/UpdateBoxForm.jsx
@@ -30,7 +30,12 @@ const formSchema = z.object({
 export default function UpdateBoxForm({ row }) {
   const { mutate, status } = useMutation({
     mutationFn: apiUpdateBox,
-    onSuccess: (data) => console.log(`box updated to ${JSON.stringify(data)}`),
+    onSuccess: () => {
+      console.log("update successfully");
+    },
+    onError: (error) => {
+      console.error("更新失敗:", error);
+    },
   });
   const form = useForm({
     defaultValues: {
@@ -46,7 +51,7 @@ export default function UpdateBoxForm({ row }) {
   function onSubmit(values) {
     try {
       console.log(values);
-      mutate({ row, values });
+      mutate(row, values);
       reset();
     } catch (error) {
       console.error("Form submission error", error);

--- a/src/components/form/UpdateBoxForm.jsx
+++ b/src/components/form/UpdateBoxForm.jsx
@@ -1,0 +1,177 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+// react query: 更新單一筆紙箱紀錄
+import { useMutation } from "@tanstack/react-query";
+import { apiUpdateBox } from "@/services/apiBoxes";
+
+const formSchema = z.object({
+  size: z.string().optional(),
+  condition: z.string().optional(),
+  retention_days: z.string().optional(),
+  status: z.string().optional(),
+});
+
+export default function UpdateBoxForm({ row }) {
+  const { mutate, status } = useMutation({
+    mutationFn: apiUpdateBox,
+    onSuccess: (data) => console.log(`box updated to ${JSON.stringify(data)}`),
+  });
+  const form = useForm({
+    defaultValues: {
+      size: row.size,
+      condition: row.condition,
+      retention_days: row.retention_days?.toString(),
+      status: row.status,
+    },
+    resolver: zodResolver(formSchema),
+  });
+  const { reset } = form;
+
+  function onSubmit(values) {
+    try {
+      console.log(values);
+      mutate({ row, values });
+      reset();
+    } catch (error) {
+      console.error("Form submission error", error);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-1.5">
+        <FormField
+          control={form.control}
+          name="size"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>紙箱大小</FormLabel>
+              <Select onValueChange={field.onChange} defaultValue={row.size}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="特大">特大</SelectItem>
+                  <SelectItem value="大">大</SelectItem>
+                  <SelectItem value="中">中</SelectItem>
+                  <SelectItem value="小">小</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="condition"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>紙箱保存等級</FormLabel>
+              <Select
+                onValueChange={field.onChange}
+                defaultValue={row.condition}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="全新">全新</SelectItem>
+                  <SelectItem value="優">優</SelectItem>
+                  <SelectItem value="普通">普通</SelectItem>
+                  <SelectItem value="差">差</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="retention_days"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>紙箱保留天數</FormLabel>
+              <Select
+                onValueChange={field.onChange}
+                defaultValue={row.retention_days?.toString()}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="7">7</SelectItem>
+                  <SelectItem value="30">30</SelectItem>
+                  <SelectItem value="60">60</SelectItem>
+                  <SelectItem value="90">90</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="status"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>紙箱狀態</FormLabel>
+              <Select onValueChange={field.onChange} defaultValue={row.status}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="可認領">可認領</SelectItem>
+                  <SelectItem value="自用">自用</SelectItem>
+                  <SelectItem value="售出">售出</SelectItem>
+                  <SelectItem value="報廢">報廢</SelectItem>
+                  <SelectItem value="保留到期">保留到期</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex">
+          <button
+            type="submit"
+            className="btn ml-auto"
+            disabled={status === "pending"}
+          >
+            {status === "pending" ? "更新中" : "確認送出"}
+          </button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/form/UpdateBoxForm.jsx
+++ b/src/components/form/UpdateBoxForm.jsx
@@ -17,31 +17,38 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useUpdateBox } from "@/hooks/useBoxes";
 
 UpdateBoxForm.propTypes = { row: PropTypes.object };
+
 const formSchema = z.object({
-  size: z.string().optional(),
-  condition: z.string().optional(),
-  retention_days: z.string().optional(),
-  status: z.string().optional(),
+  size: z.string(),
+  condition: z.string(),
+  retention_days: z.number(),
+  status: z.string(),
 });
 
 export default function UpdateBoxForm({ row }) {
+  const { updateBox, isUpdating } = useUpdateBox();
+
   const form = useForm({
     defaultValues: {
       size: row.size,
       condition: row.condition,
-      retention_days: row.retention_days?.toString(),
+      retention_days: Number(row.retention_days),
       status: row.status,
     },
     resolver: zodResolver(formSchema),
   });
-  const { reset } = form;
 
   function onSubmit(values) {
+    const formattedValues = {
+      ...values,
+      retention_days: Number(values.retention_days),
+    };
     try {
-      console.log(values);
-      reset();
+      updateBox({ boxId: row.id, values: formattedValues });
+      console.log(row.id, formattedValues);
     } catch (error) {
       console.error("Form submission error", error);
     }
@@ -110,8 +117,8 @@ export default function UpdateBoxForm({ row }) {
             <FormItem>
               <FormLabel>紙箱保留天數</FormLabel>
               <Select
-                onValueChange={field.onChange}
-                defaultValue={row.retention_days?.toString()}
+                onValueChange={(value) => field.onChange(Number(value))}
+                defaultValue={row.retention_days.toString()}
               >
                 <FormControl>
                   <SelectTrigger>
@@ -157,12 +164,8 @@ export default function UpdateBoxForm({ row }) {
           )}
         />
         <div className="flex">
-          <button
-            type="submit"
-            className="btn ml-auto"
-            disabled={status === "pending"}
-          >
-            {status === "pending" ? "更新中" : "確認送出"}
+          <button type="submit" className="btn ml-auto" disabled={isUpdating}>
+            {isUpdating ? "更新中" : "確認送出"}
           </button>
         </div>
       </form>

--- a/src/components/form/UpdateBoxForm.jsx
+++ b/src/components/form/UpdateBoxForm.jsx
@@ -1,5 +1,6 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import PropTypes from "prop-types";
 import * as z from "zod";
 import {
   Form,
@@ -16,10 +17,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-// react query: 更新單一筆紙箱紀錄
-import { useMutation } from "@tanstack/react-query";
-import { apiUpdateBox } from "@/services/apiBoxes";
 
+UpdateBoxForm.propTypes = { row: PropTypes.object };
 const formSchema = z.object({
   size: z.string().optional(),
   condition: z.string().optional(),
@@ -28,15 +27,6 @@ const formSchema = z.object({
 });
 
 export default function UpdateBoxForm({ row }) {
-  const { mutate, status } = useMutation({
-    mutationFn: apiUpdateBox,
-    onSuccess: () => {
-      console.log("update successfully");
-    },
-    onError: (error) => {
-      console.error("更新失敗:", error);
-    },
-  });
   const form = useForm({
     defaultValues: {
       size: row.size,
@@ -51,7 +41,6 @@ export default function UpdateBoxForm({ row }) {
   function onSubmit(values) {
     try {
       console.log(values);
-      mutate(row, values);
       reset();
     } catch (error) {
       console.error("Form submission error", error);

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -193,19 +193,3 @@ const AdminBoxManageTable = () => {
 };
 
 export default AdminBoxManageTable;
-
-{
-  /* <div className='flex justify-between w-full'>
-          <input
-            type="text"
-            placeholder="搜尋紙箱編號"
-            value={filterText}
-            onChange={(e) => setFilterText(e.target.value)}
-            className="p-2 border rounded "
-          />
-          <div className='flex gap-5'>
-            <button className="btn p-2 border flex items-center"><FaFolderPlus /> 新增紙箱</button>
-            <button className="btn p-2 border flex items-center"><FaCashRegister /> 交易紙箱</button>
-          </div>
-        </div> */
-}

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -1,14 +1,13 @@
 // 5-3 回收站點管理者後台 - 待認領／自用紙箱列表
+import { useState } from "react";
+// React Data Table Component
 import DataTable from "react-data-table-component";
 import { StyleSheetManager } from "styled-components";
 import isPropValid from "@emotion/is-prop-valid";
-import { useState } from "react";
-
 // react query
 import { useBoxesForAdminManaging } from "../..//hooks/useBoxes";
 import Spinner from "../../components/Spinner";
 import ErrorMessage from "../../components/ErrorMessage";
-
 // shadcn
 import {
   Dialog,
@@ -22,8 +21,8 @@ import {
 import { FaPen } from "react-icons/fa";
 import { FaTrashAlt } from "react-icons/fa";
 import { FaFolderPlus, FaCashRegister } from "react-icons/fa";
-
-import UpdateBoxesForm from "../form/UpdateBoxesForm";
+// 更新紙箱資料表單元件
+import UpdateBoxForm from "../form/UpdateBoxForm";
 
 // 表格內客製化樣式 (或建立style.css覆蓋樣式)
 const customStyles = {
@@ -146,7 +145,7 @@ const AdminBoxManageTable = () => {
                   </p>
                 </div>
               </div>
-              <UpdateBoxesForm row={row} />
+              <UpdateBoxForm row={row} />
             </DialogContent>
           </Dialog>
           <button className="rounded-md bg-red-600 p-2 text-white hover:bg-red-500 focus-visible:outline-none">

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -7,11 +7,19 @@ import { FaPen } from "react-icons/fa";
 import { FaTrashAlt } from "react-icons/fa";
 import { FaFolderPlus, FaCashRegister } from "react-icons/fa";
 
-import { useBoxesForSelling } from "../..//hooks/useBoxes";
+import { useBoxesForAdminManaging } from "../..//hooks/useBoxes";
 import Spinner from "../../components/Spinner";
 import ErrorMessage from "../../components/ErrorMessage";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 
-import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import UpdateBoxesForm from "../form/UpdateBoxesForm";
 
 // 表格內客製化樣式 (或建立style.css覆蓋樣式)
 const customStyles = {
@@ -56,12 +64,6 @@ const paginationComponentOptions = {
   selectAllRowsItemText: "全部",
 };
 
-const style = {
-  selectContainer: "mb-4 flex items-center justify-between",
-  select:
-    "fs-6 w-2/3 rounded-sm border p-1 text-black placeholder:text-[#B7B7B7] focus-visible:outline-none",
-};
-
 const AdminBoxManageTable = () => {
   // 篩選搜尋資料
   const [filterText, setFilterText] = useState("");
@@ -71,8 +73,8 @@ const AdminBoxManageTable = () => {
   //   )
   // );
 
-  // 取得紙箱資廖
-  const { boxes, isLoadingBoxes, boxesError } = useBoxesForSelling();
+  // 取得可認領紙箱資料
+  const { boxes, isLoadingBoxes, boxesError } = useBoxesForAdminManaging();
   if (isLoadingBoxes) return <Spinner />;
   if (boxesError) return <ErrorMessage errorMessage={boxesError.message} />;
 
@@ -112,87 +114,38 @@ const AdminBoxManageTable = () => {
       selector: (row) => (
         <div className="flex gap-2">
           <Dialog>
-            <DialogTrigger className="rounded-md bg-main-600 p-2 text-white hover:bg-main-500 focus-visible:outline-none">
-              <FaPen />
+            <DialogTrigger asChild>
+              <button className="rounded-md bg-main-600 p-2 text-white hover:bg-main-500 focus-visible:outline-none">
+                <FaPen />
+              </button>
             </DialogTrigger>
-            <DialogContent>
-              <div className="flex gap-4">
-                <img
-                  src={row.image_url}
-                  alt="照片"
-                  className="h-[100px] w-[100px]"
-                />
-                <div>
+            <DialogContent className="sm:max-w-[500px]">
+              <DialogHeader>
+                <DialogTitle>編輯紙箱</DialogTitle>
+                <DialogDescription>編輯紙箱資訊</DialogDescription>
+              </DialogHeader>
+              <div className="flex gap-2">
+                <img src={row.image_url} alt="照片" className="w-1/4" />
+                <div className="flex flex-col">
+                  <p>紙箱編號：{row.id}</p>
                   <p>
-                    新增時間： {row.created_at.replace("T", " ").slice(0, 16)}
+                    新增時間：{row.created_at.replace("T", " ").slice(0, 16)}
                   </p>
-                  <p>回收會員： {row.user_id}</p>
-                  <p>紙箱編號： {row.id}</p>
+                  <p>
+                    更新時間：{row.updated_at.replace("T", " ").slice(0, 16)}
+                  </p>
+                  <p className="text-red-500">
+                    保存到期日：{row.updated_at.replace("T", " ").slice(0, 16)}
+                  </p>
+                  <p className="text-red-500">
+                    回收會員：{row.user_id.slice(0, 16)}
+                  </p>
                 </div>
               </div>
-              <form>
-                <div className={style.selectContainer}>
-                  <label htmlFor="size">紙箱大小</label>
-                  <select id="size" className={style.select} value={row.size}>
-                    <option value="特大">特大</option>
-                    <option value="大">大</option>
-                    <option value="中">中</option>
-                    <option value="小">小</option>
-                  </select>
-                </div>
-                <div className={style.selectContainer}>
-                  <label htmlFor="condition">紙箱保存等級</label>
-                  <select
-                    id="condition"
-                    className={style.select}
-                    value={row.condition}
-                  >
-                    <option value="全新">全新</option>
-                    <option value="優">優</option>
-                    <option value="普通">普通</option>
-                    <option value="差">差</option>
-                  </select>
-                </div>
-                <div className={style.selectContainer}>
-                  <label htmlFor="retention_days">紙箱保留天數</label>
-                  <select
-                    id="retention_days"
-                    className={style.select}
-                    value={row.retention_days}
-                  >
-                    <option value="7">7</option>
-                    <option value="30">30</option>
-                    <option value="60">60</option>
-                    <option value="90">90</option>
-                  </select>
-                </div>
-                <div className={style.selectContainer}>
-                  <p>保存到期日</p>
-                  <p className="text-left">2025/02/25</p>
-                </div>
-                <div className={style.selectContainer}>
-                  <label htmlFor="status">紙箱狀態</label>
-                  <select
-                    id="status"
-                    className={style.select}
-                    value={row.status}
-                  >
-                    <option value="可認領">可認領</option>
-                    <option value="自用">自用</option>
-                    <option value="售出">售出</option>
-                    <option value="報廢">被廢</option>
-                    <option value="保留到期">保留到期</option>
-                  </select>
-                </div>
-                <div className="text-right">
-                  <button className="btn" onClick={(e) => e.preventDefault()}>
-                    確認送出
-                  </button>
-                </div>
-              </form>
+              <UpdateBoxesForm row={row} />
             </DialogContent>
           </Dialog>
-          <button className="rounded-md bg-red-600 p-2 text-white hover:bg-red-500">
+          <button className="rounded-md bg-red-600 p-2 text-white hover:bg-red-500 focus-visible:outline-none">
             <FaTrashAlt />
           </button>
         </div>

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -1,15 +1,15 @@
 // 5-3 回收站點管理者後台 - 待認領／自用紙箱列表
-import { useState } from "react";
 import DataTable from "react-data-table-component";
 import { StyleSheetManager } from "styled-components";
 import isPropValid from "@emotion/is-prop-valid";
-import { FaPen } from "react-icons/fa";
-import { FaTrashAlt } from "react-icons/fa";
-import { FaFolderPlus, FaCashRegister } from "react-icons/fa";
+import { useState } from "react";
 
+// react query
 import { useBoxesForAdminManaging } from "../..//hooks/useBoxes";
 import Spinner from "../../components/Spinner";
 import ErrorMessage from "../../components/ErrorMessage";
+
+// shadcn
 import {
   Dialog,
   DialogContent,
@@ -18,6 +18,10 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+// react icons
+import { FaPen } from "react-icons/fa";
+import { FaTrashAlt } from "react-icons/fa";
+import { FaFolderPlus, FaCashRegister } from "react-icons/fa";
 
 import UpdateBoxesForm from "../form/UpdateBoxesForm";
 

--- a/src/components/table/AdminDeprecatedTable.jsx
+++ b/src/components/table/AdminDeprecatedTable.jsx
@@ -1,16 +1,14 @@
 // 5-4 待回收紙箱列表（報廢）
 import { useState } from "react";
+// React Data Table Component
 import DataTable from "react-data-table-component";
 import { StyleSheetManager } from "styled-components";
 import isPropValid from "@emotion/is-prop-valid";
-import { FaPen } from "react-icons/fa";
-import { FaTrashAlt } from "react-icons/fa";
-
+// react query
 import { useBoxesForScraping } from "@/hooks/useBoxes";
 import Spinner from "@/components/Spinner";
 import ErrorMessage from "@/components/ErrorMessage";
-import UpdateBoxesForm from "@/components/form/UpdateBoxesForm";
-
+// shadcn
 import {
   Dialog,
   DialogContent,
@@ -19,6 +17,11 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+// react icons
+import { FaPen } from "react-icons/fa";
+import { FaTrashAlt } from "react-icons/fa";
+// 更新紙箱資料表單元件
+import UpdateBoxForm from "../form/UpdateBoxForm";
 
 // 表格內客製化樣式 (或建立style.css覆蓋樣式)
 const customStyles = {
@@ -141,7 +144,7 @@ const AdminDeprecatedTable = () => {
                   </p>
                 </div>
               </div>
-              <UpdateBoxesForm row={row} />
+              <UpdateBoxForm row={row} />
             </DialogContent>
           </Dialog>
           <button className="rounded-md bg-red-600 p-2 text-white hover:bg-red-500 focus-visible:outline-none">

--- a/src/components/table/AdminDeprecatedTable.jsx
+++ b/src/components/table/AdminDeprecatedTable.jsx
@@ -6,11 +6,19 @@ import isPropValid from "@emotion/is-prop-valid";
 import { FaPen } from "react-icons/fa";
 import { FaTrashAlt } from "react-icons/fa";
 
-import { useBoxesForScraping } from "../..//hooks/useBoxes";
-import Spinner from "../../components/Spinner";
-import ErrorMessage from "../../components/ErrorMessage";
+import { useBoxesForScraping } from "@/hooks/useBoxes";
+import Spinner from "@/components/Spinner";
+import ErrorMessage from "@/components/ErrorMessage";
+import UpdateBoxesForm from "@/components/form/UpdateBoxesForm";
 
-import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 
 // 表格內客製化樣式 (或建立style.css覆蓋樣式)
 const customStyles = {
@@ -55,12 +63,6 @@ const paginationComponentOptions = {
   selectAllRowsItemText: "全部",
 };
 
-const style = {
-  selectContainer: "mb-4 flex items-center justify-between",
-  select:
-    "fs-6 w-2/3 rounded-sm border p-1 text-black placeholder:text-[#B7B7B7] focus-visible:outline-none",
-};
-
 const AdminDeprecatedTable = () => {
   // 篩選搜尋資料
   const [filterText, setFilterText] = useState("");
@@ -70,7 +72,7 @@ const AdminDeprecatedTable = () => {
   //   )
   // );
 
-  // 取得紙箱資廖
+  // 取得報廢紙箱資料
   const { boxes, isLoadingBoxes, boxesError } = useBoxesForScraping();
   if (isLoadingBoxes) return <Spinner />;
   if (boxesError) return <ErrorMessage errorMessage={boxesError.message} />;
@@ -111,87 +113,38 @@ const AdminDeprecatedTable = () => {
       selector: (row) => (
         <div className="flex gap-2">
           <Dialog>
-            <DialogTrigger className="rounded-md bg-main-600 p-2 text-white hover:bg-main-500 focus-visible:outline-none">
-              <FaPen />
+            <DialogTrigger asChild>
+              <button className="rounded-md bg-main-600 p-2 text-white hover:bg-main-500 focus-visible:outline-none">
+                <FaPen />
+              </button>
             </DialogTrigger>
-            <DialogContent>
-              <div className="flex gap-4">
-                <img
-                  src={row.image_url}
-                  alt="照片"
-                  className="h-[100px] w-[100px]"
-                />
-                <div>
+            <DialogContent className="sm:max-w-[500px]">
+              <DialogHeader>
+                <DialogTitle>編輯紙箱</DialogTitle>
+                <DialogDescription>編輯紙箱資訊</DialogDescription>
+              </DialogHeader>
+              <div className="flex gap-2">
+                <img src={row.image_url} alt="照片" className="w-1/4" />
+                <div className="flex flex-col">
+                  <p>紙箱編號：{row.id}</p>
                   <p>
-                    新增時間： {row.created_at.replace("T", " ").slice(0, 16)}
+                    新增時間：{row.created_at.replace("T", " ").slice(0, 16)}
                   </p>
-                  <p>回收會員： {row.user_id}</p>
-                  <p>紙箱編號： {row.id}</p>
+                  <p>
+                    更新時間：{row.updated_at.replace("T", " ").slice(0, 16)}
+                  </p>
+                  <p className="text-red-500">
+                    保存到期日：{row.updated_at.replace("T", " ").slice(0, 16)}
+                  </p>
+                  <p className="text-red-500">
+                    回收會員：{row.user_id.slice(0, 16)}
+                  </p>
                 </div>
               </div>
-              <form>
-                <div className={style.selectContainer}>
-                  <label htmlFor="size">紙箱大小</label>
-                  <select id="size" className={style.select} value={row.size}>
-                    <option value="特大">特大</option>
-                    <option value="大">大</option>
-                    <option value="中">中</option>
-                    <option value="小">小</option>
-                  </select>
-                </div>
-                <div className={style.selectContainer}>
-                  <label htmlFor="condition">紙箱保存等級</label>
-                  <select
-                    id="condition"
-                    className={style.select}
-                    value={row.condition}
-                  >
-                    <option value="全新">全新</option>
-                    <option value="優">優</option>
-                    <option value="普通">普通</option>
-                    <option value="差">差</option>
-                  </select>
-                </div>
-                <div className={style.selectContainer}>
-                  <label htmlFor="retention_days">紙箱保留天數</label>
-                  <select
-                    id="retention_days"
-                    className={style.select}
-                    value={row.retention_days}
-                  >
-                    <option value="7">7</option>
-                    <option value="30">30</option>
-                    <option value="60">60</option>
-                    <option value="90">90</option>
-                  </select>
-                </div>
-                <div className={style.selectContainer}>
-                  <p>保存到期日</p>
-                  <p className="text-left">2025/02/25</p>
-                </div>
-                <div className={style.selectContainer}>
-                  <label htmlFor="status">紙箱狀態</label>
-                  <select
-                    id="status"
-                    className={style.select}
-                    value={row.status}
-                  >
-                    <option value="可認領">可認領</option>
-                    <option value="自用">自用</option>
-                    <option value="售出">售出</option>
-                    <option value="報廢">被廢</option>
-                    <option value="保留到期">保留到期</option>
-                  </select>
-                </div>
-                <div className="text-right">
-                  <button className="btn" onClick={(e) => e.preventDefault()}>
-                    確認送出
-                  </button>
-                </div>
-              </form>
+              <UpdateBoxesForm row={row} />
             </DialogContent>
           </Dialog>
-          <button className="rounded-md bg-red-600 p-2 text-white hover:bg-red-500">
+          <button className="rounded-md bg-red-600 p-2 text-white hover:bg-red-500 focus-visible:outline-none">
             <FaTrashAlt />
           </button>
         </div>

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -1,0 +1,119 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}>
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}>
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}>
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}>
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn("p-1", position === "popper" &&
+          "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]")}>
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props} />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}>
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props} />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -1,5 +1,6 @@
 import {
   apiGetBoxesForSelling,
+  apiGetBoxesForAdminManaging,
   apiGetBoxesForScraping,
 } from "@/services/apiBoxes";
 import { useQuery } from "@tanstack/react-query";
@@ -21,6 +22,28 @@ export function useBoxesForSelling() {
   } = useQuery({
     queryKey: ["boxes", "selling"],
     queryFn: apiGetBoxesForSelling,
+  });
+
+  return { boxes, isLoadingBoxes, boxesError };
+}
+/**
+ * 自訂 Hook：使用 React Query 來取得紙箱資料
+ *
+ * 使用 `useQuery` 來向 API 請求紙箱資料，並處理資料加載與錯誤狀態。
+ *
+ * @returns {Object} 返回包含三個屬性的物件：
+ *   - `boxes` {Array|null} - 紙箱資料陣列，若尚未請求或發生錯誤則為 `null`
+ *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
+ *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
+ */
+export function useBoxesForAdminManaging() {
+  const {
+    data: boxes,
+    isLoading: isLoadingBoxes,
+    error: boxesError,
+  } = useQuery({
+    queryKey: ["boxes", "managing"],
+    queryFn: apiGetBoxesForAdminManaging,
   });
 
   return { boxes, isLoadingBoxes, boxesError };

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -5,9 +5,9 @@ import {
 } from "@/services/apiBoxes";
 import { useQuery } from "@tanstack/react-query";
 /**
- * 自訂 Hook：使用 React Query 來取得紙箱資料
+ * 自訂 Hook：使用 React Query 來取得紙箱狀態為可認領的紙箱資料
  *
- * 使用 `useQuery` 來向 API 請求紙箱資料，並處理資料加載與錯誤狀態。
+ * 使用 `useQuery` 來向 API 請求紙箱狀態為可認領的紙箱資料，並處理資料加載與錯誤狀態。
  *
  * @returns {Object} 返回包含三個屬性的物件：
  *   - `boxes` {Array|null} - 紙箱資料陣列，若尚未請求或發生錯誤則為 `null`
@@ -27,9 +27,9 @@ export function useBoxesForSelling() {
   return { boxes, isLoadingBoxes, boxesError };
 }
 /**
- * 自訂 Hook：使用 React Query 來取得紙箱資料
+ * 自訂 Hook：使用 React Query 來取得 5-3 可認領紙箱列表的紙箱資料
  *
- * 使用 `useQuery` 來向 API 請求紙箱資料，並處理資料加載與錯誤狀態。
+ * 使用 `useQuery` 來向 API 請求可認領紙箱列表的紙箱資料，並處理資料加載與錯誤狀態。
  *
  * @returns {Object} 返回包含三個屬性的物件：
  *   - `boxes` {Array|null} - 紙箱資料陣列，若尚未請求或發生錯誤則為 `null`
@@ -50,9 +50,9 @@ export function useBoxesForAdminManaging() {
 }
 
 /**
- * 自訂 Hook：使用 React Query 來取得紙箱資料
+ * 自訂 Hook：使用 React Query 來取得 5-4 待回收紙箱列表的紙箱資料
  *
- * 使用 `useQuery` 來向 API 請求紙箱資料，並處理資料加載與錯誤狀態。
+ * 使用 `useQuery` 來向 API 請求 5-4 待回收紙箱列表的紙箱資料，並處理資料加載與錯誤狀態。
  *
  * @returns {Object} 返回包含三個屬性的物件：
  *   - `boxes` {Array|null} - 紙箱資料陣列，若尚未請求或發生錯誤則為 `null`

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -3,7 +3,8 @@ import {
   apiGetBoxesForAdminManaging,
   apiGetBoxesForScraping,
 } from "@/services/apiBoxes";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { apiUpdateBox } from "@/services/apiBoxes";
 /**
  * 自訂 Hook：使用 React Query 來取得紙箱狀態為可認領的紙箱資料
  *
@@ -70,4 +71,17 @@ export function useBoxesForScraping() {
   });
 
   return { boxes, isLoadingBoxes, boxesError };
+}
+
+export function updateBox() {
+  const { mutate: updateBox } = useMutation({
+    mutationFn: apiUpdateBox,
+    onSuccess: () => {
+      console.log("update successfully");
+    },
+    onError: (error) => {
+      console.error("更新失敗:", error);
+    },
+  });
+  return { updateBox };
 }

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -3,7 +3,8 @@ import {
   apiGetBoxesForAdminManaging,
   apiGetBoxesForScraping,
 } from "@/services/apiBoxes";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiUpdateBox } from "@/services/apiBoxes";
 /**
  * 自訂 Hook：使用 React Query 來取得紙箱狀態為可認領的紙箱資料
@@ -73,15 +74,22 @@ export function useBoxesForScraping() {
   return { boxes, isLoadingBoxes, boxesError };
 }
 
-export function updateBox() {
-  const { mutate: updateBox } = useMutation({
-    mutationFn: apiUpdateBox,
+// 更新單一筆紙箱資料
+export function useUpdateBox() {
+  const queryClient = useQueryClient();
+  const {
+    mutate: updateBox,
+    error: updatedError,
+    isPending: isUpdating,
+  } = useMutation({
+    mutationFn: ({ boxId, values }) => apiUpdateBox(boxId, values),
     onSuccess: () => {
-      console.log("update successfully");
+      toast.success("更新成功");
+      queryClient.invalidateQueries({ queryKey: ["boxes", "managing"] });
     },
     onError: (error) => {
-      console.error("更新失敗:", error);
+      toast.error(error.message);
     },
   });
-  return { updateBox };
+  return { updateBox, updatedError, isUpdating };
 }

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -1,9 +1,9 @@
 import supabase from "./supabase";
 
 /**
- * 從 Supabase 取得所有紙箱資料
+ * 從 Supabase 取得紙箱狀態為可認領的紙箱資料
  *
- * 該函式向 Supabase 的 `boxes` 表格請求可認領紙箱列表的資料，並處理錯誤。
+ * 該函式向 Supabase 的 `boxes` 表格請求紙箱狀態為可認領的資料，並處理錯誤。
  *
  * @async
  * @function apiGetBoxesForSelling
@@ -11,6 +11,34 @@ import supabase from "./supabase";
  * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
  */
 export async function apiGetBoxesForSelling() {
+  try {
+    let { data: boxes, error } = await supabase
+      .from("boxes")
+      .select("*")
+      .in("status", ["可認領"]);
+
+    if (error) throw error;
+
+    return boxes;
+  } catch (error) {
+    // supabase 錯誤內容
+    console.error(error);
+    // UI 顯示的錯誤內容
+    throw new Error("無法取得 boxes 資料，請稍後再試");
+  }
+}
+
+/**
+ * 從 Supabase 取得 5-3 可認領紙箱列表的紙箱資料
+ *
+ * 該函式向 Supabase 的 `boxes` 表格請求 5-3 可認領紙箱列表的資料，並處理錯誤。
+ *
+ * @async
+ * @function apiGetBoxesForAdminManaging
+ * @returns {Promise<Array>} 紙箱資料陣列，若請求成功返回資料，若失敗則會拋出錯誤
+ * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
+ */
+export async function apiGetBoxesForAdminManaging() {
   try {
     let { data: boxes, error } = await supabase
       .from("boxes")
@@ -29,9 +57,9 @@ export async function apiGetBoxesForSelling() {
 }
 
 /**
- * 從 Supabase 取得所有紙箱資料
+ * 從 Supabase 取得 5-4 待回收紙箱列表的紙箱資料
  *
- * 該函式向 Supabase 的 `boxes` 表格請求待回收紙箱列表的資料，並處理錯誤。
+ * 該函式向 Supabase 的 `boxes` 表格請求 5-4 待回收紙箱列表的資料，並處理錯誤。
  *
  * @async
  * @function apiGetBoxesForScraping

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -99,7 +99,7 @@ export async function apiUpdateBox({ row, values }) {
   try {
     const { data: box, error } = await supabase
       .from("boxes")
-      .update({ ...values, updated_at: new Date() })
+      .update({ ...values, updated_at: Date.now() })
       .eq("id", row.id)
       .select();
 

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -95,15 +95,15 @@ export async function apiGetBoxesForScraping() {
  * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
  */
 
-export async function apiUpdateBox({ row, values }) {
+export async function apiUpdateBox(boxId, values) {
   try {
     const { data: box, error } = await supabase
       .from("boxes")
-      .update({ ...values, updated_at: Date.now() })
-      .eq("id", row.id)
+      .update({ ...values, updated_at: new Date() })
+      .eq("id", boxId)
       .select();
-
     if (error) throw error;
+    if (!box) throw new Error("更新失敗，請檢查 ID 是否正確");
 
     return box;
   } catch (error) {

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -83,3 +83,33 @@ export async function apiGetBoxesForScraping() {
     throw new Error("無法取得 boxes 資料，請稍後再試");
   }
 }
+
+/**
+ * 從 Supabase 更新單一筆紙箱資料
+ *
+ * 該函式向 Supabase 的 `boxes` 表格更新單一筆的紙箱資料，並處理錯誤。
+ *
+ * @async
+ * @function apiUpdateBox
+ * @returns {Promise<Array>} 紙箱資料陣列，若請求成功返回資料，若失敗則會拋出錯誤
+ * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
+ */
+
+export async function apiUpdateBox({ row, values }) {
+  try {
+    const { data: box, error } = await supabase
+      .from("boxes")
+      .update({ ...values, updated_at: new Date() })
+      .eq("id", row.id)
+      .select();
+
+    if (error) throw error;
+
+    return box;
+  } catch (error) {
+    // supabase 錯誤內容
+    console.error(error);
+    // UI 顯示的錯誤內容
+    throw new Error("無法更新 boxes 資料，請稍後再試");
+  }
+}


### PR DESCRIPTION
### **主要修改**

- 調整 `components/Table/AdminBoxManageTable.jsx` 與 `components/Table/AdminDeprecatedTable.jsx` 樣式與資料串接
  - 修改成react hook form + zod 驗證 
  - 讀取紙箱API 串接
  - 編輯紙箱API 串接


### **其他未完成事項**
- **API 相關:**  
  - `apiBoxes.js` : 更新及刪除API 尚未完成
 
- **Table 相關**
  - 搜尋功能尚未完善
  - 新增紙箱、清空表單、刪除紙箱等按鈕僅切版、功能尚未完成
  
---

### **測試方式**
- [ ] 呼叫 `useUpdateBox` 是否能正確更新單一筆紙箱資料並即時更新列表紙箱資料 ?
- [ ] 呼叫 `useBoxesForAdminManaging` 是否能取得紙箱狀態為 `["售出", "自用", "可認領"]` 紙箱資料？  
- [ ] 呼叫 `useBoxesForScraping` 是否能取得紙箱狀態為`["報廢", "保留到期"]` 紙箱資料？
- [ ] 進入 `member/admit/boxesTable` 路由 是否可以正確渲染 Table元件並僅讀取 `["售出", "自用", "可認領"]`紙箱資料?
- [ ] 進入 `member/admit/recyclingTable` 路由 是否可以正確渲染 Table元件並僅讀取`["報廢", "保留到期"]` 紙箱資料?

issue #10 
