### PR TITLE
Feature: 更新 5-3、5-4 編輯按鈕Dialog、新增刪除按鈕Dialog

### DIFF
--- a/src/components/dialog/DeleteBoxDialog.jsx
+++ b/src/components/dialog/DeleteBoxDialog.jsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+DeleteBoxDialog.propTypes = { row: PropTypes.object };
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+import { FaTrashAlt } from "react-icons/fa";
+import toast from "react-hot-toast";
+
+function DeleteBoxDialog({ row }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <button className="rounded-md bg-red-600 p-2 text-white hover:bg-red-500 focus-visible:outline-none">
+            <FaTrashAlt />
+          </button>
+        </DialogTrigger>
+
+        <DialogContent inert={!open}>
+          <DialogHeader>
+            <DialogTitle>刪除紙箱</DialogTitle>
+            <DialogDescription>
+              確定要刪除 紙箱編號：{row.id} 的紙箱嗎?
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex justify-end gap-2">
+            <button
+              className="btn-cancel"
+              onClick={() => {
+                setOpen(false);
+                toast.error("取消刪除");
+              }}
+            >
+              取消
+            </button>
+            <button
+              className="btn-delete"
+              onClick={() => {
+                setOpen(false);
+                toast.success("刪除成功");
+              }}
+            >
+              刪除
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+export default DeleteBoxDialog;

--- a/src/components/dialog/UpdateBoxDialog.jsx
+++ b/src/components/dialog/UpdateBoxDialog.jsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+UpdateBoxDialog.propTypes = { row: PropTypes.object };
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import UpdateBoxForm from "../form/UpdateBoxForm";
+import { FaPen } from "react-icons/fa";
+
+function UpdateBoxDialog({ row }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <button className="rounded-md bg-main-600 p-2 text-white hover:bg-main-500 focus-visible:outline-none">
+            <FaPen />
+          </button>
+        </DialogTrigger>
+
+        <DialogContent inert={!open}>
+          <DialogHeader>
+            <DialogTitle>編輯紙箱</DialogTitle>
+            <DialogDescription>編輯紙箱資訊</DialogDescription>
+          </DialogHeader>
+          <div className="flex gap-2">
+            <img src={row.image_url} alt="照片" className="w-1/4" />
+            <div className="flex flex-col">
+              <p>紙箱編號：{row.id}</p>
+              <p>新增時間：{row.created_at?.replace("T", " ").slice(0, 16)}</p>
+              <p>更新時間：{row.updated_at?.replace("T", " ").slice(0, 16)}</p>
+              <p className="text-red-500">
+                保存到期日：
+                {row.updated_at?.replace("T", " ").slice(0, 16)}
+              </p>
+              <p className="text-red-500">
+                回收會員：{row.user_id?.slice(0, 16)}
+              </p>
+            </div>
+          </div>
+          <UpdateBoxForm row={row} setOpen={setOpen} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+export default UpdateBoxDialog;

--- a/src/components/form/UpdateBoxForm.jsx
+++ b/src/components/form/UpdateBoxForm.jsx
@@ -1,5 +1,6 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import toast from "react-hot-toast";
 import PropTypes from "prop-types";
 import * as z from "zod";
 import {
@@ -19,7 +20,7 @@ import {
 } from "@/components/ui/select";
 import { useUpdateBox } from "@/hooks/useBoxes";
 
-UpdateBoxForm.propTypes = { row: PropTypes.object };
+UpdateBoxForm.propTypes = { row: PropTypes.object, setOpen: PropTypes.func };
 
 const formSchema = z.object({
   size: z.string(),
@@ -28,14 +29,13 @@ const formSchema = z.object({
   status: z.string(),
 });
 
-export default function UpdateBoxForm({ row }) {
+export default function UpdateBoxForm({ row, setOpen }) {
   const { updateBox, isUpdating } = useUpdateBox();
-
   const form = useForm({
     defaultValues: {
       size: row.size,
       condition: row.condition,
-      retention_days: Number(row.retention_days),
+      retention_days: row.retention_days,
       status: row.status,
     },
     resolver: zodResolver(formSchema),
@@ -49,6 +49,7 @@ export default function UpdateBoxForm({ row }) {
     try {
       updateBox({ boxId: row.id, values: formattedValues });
       console.log(row.id, formattedValues);
+      setOpen(false);
     } catch (error) {
       console.error("Form submission error", error);
     }
@@ -118,7 +119,7 @@ export default function UpdateBoxForm({ row }) {
               <FormLabel>紙箱保留天數</FormLabel>
               <Select
                 onValueChange={(value) => field.onChange(Number(value))}
-                defaultValue={row.retention_days.toString()}
+                defaultValue={row.retention_days?.toString()}
               >
                 <FormControl>
                   <SelectTrigger>
@@ -163,9 +164,19 @@ export default function UpdateBoxForm({ row }) {
             </FormItem>
           )}
         />
-        <div className="flex">
-          <button type="submit" className="btn ml-auto" disabled={isUpdating}>
-            {isUpdating ? "更新中" : "確認送出"}
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            className="btn-cancel"
+            onClick={() => {
+              setOpen(false);
+              toast.error("取消更新");
+            }}
+          >
+            取消
+          </button>
+          <button type="submit" className="btn" disabled={isUpdating}>
+            {isUpdating ? "更新中" : "確認"}
           </button>
         </div>
       </form>

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -8,21 +8,11 @@ import isPropValid from "@emotion/is-prop-valid";
 import { useBoxesForAdminManaging } from "../..//hooks/useBoxes";
 import Spinner from "../../components/Spinner";
 import ErrorMessage from "../../components/ErrorMessage";
-// shadcn
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogDescription,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
 // react icons
-import { FaPen } from "react-icons/fa";
-import { FaTrashAlt } from "react-icons/fa";
 import { FaFolderPlus, FaCashRegister } from "react-icons/fa";
-// 更新紙箱資料表單元件
-import UpdateBoxForm from "../form/UpdateBoxForm";
+// 更新紙箱、刪除紙箱資料表單元件
+import UpdateBoxDialog from "../dialog/UpdateBoxDialog";
+import DeleteBoxDialog from "../dialog/DeleteBoxDialog";
 
 // 表格內客製化樣式 (或建立style.css覆蓋樣式)
 const customStyles = {
@@ -86,13 +76,13 @@ const AdminBoxManageTable = () => {
     { name: "紙箱編號", selector: (row) => row.id, sortable: true },
     {
       name: "新增時間",
-      selector: (row) => row.created_at.replace("T", " ").slice(0, 16),
+      selector: (row) => row.created_at?.replace("T", " ").slice(0, 16),
       sortable: true,
       width: "140px",
     },
     {
       name: "更新時間",
-      selector: (row) => row.updated_at.replace("T", " ").slice(0, 16),
+      selector: (row) => row.updated_at?.replace("T", " ").slice(0, 16),
       sortable: true,
       width: "140px",
     },
@@ -116,45 +106,13 @@ const AdminBoxManageTable = () => {
       name: "編輯",
       selector: (row) => (
         <div className="flex gap-2">
-          <Dialog>
-            <DialogTrigger asChild>
-              <button className="rounded-md bg-main-600 p-2 text-white hover:bg-main-500 focus-visible:outline-none">
-                <FaPen />
-              </button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-[500px]">
-              <DialogHeader>
-                <DialogTitle>編輯紙箱</DialogTitle>
-                <DialogDescription>編輯紙箱資訊</DialogDescription>
-              </DialogHeader>
-              <div className="flex gap-2">
-                <img src={row.image_url} alt="照片" className="w-1/4" />
-                <div className="flex flex-col">
-                  <p>紙箱編號：{row.id}</p>
-                  <p>
-                    新增時間：{row.created_at.replace("T", " ").slice(0, 16)}
-                  </p>
-                  <p>
-                    更新時間：{row.updated_at.replace("T", " ").slice(0, 16)}
-                  </p>
-                  <p className="text-red-500">
-                    保存到期日：{row.updated_at.replace("T", " ").slice(0, 16)}
-                  </p>
-                  <p className="text-red-500">
-                    回收會員：{row.user_id.slice(0, 16)}
-                  </p>
-                </div>
-              </div>
-              <UpdateBoxForm row={row} />
-            </DialogContent>
-          </Dialog>
-          <button className="rounded-md bg-red-600 p-2 text-white hover:bg-red-500 focus-visible:outline-none">
-            <FaTrashAlt />
-          </button>
+          <UpdateBoxDialog row={row} />
+          <DeleteBoxDialog row={row} />
         </div>
       ),
     },
   ];
+
   const data = [...boxes];
 
   return (

--- a/src/components/table/AdminDeprecatedTable.jsx
+++ b/src/components/table/AdminDeprecatedTable.jsx
@@ -8,20 +8,10 @@ import isPropValid from "@emotion/is-prop-valid";
 import { useBoxesForScraping } from "@/hooks/useBoxes";
 import Spinner from "@/components/Spinner";
 import ErrorMessage from "@/components/ErrorMessage";
-// shadcn
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogDescription,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-// react icons
-import { FaPen } from "react-icons/fa";
 import { FaTrashAlt } from "react-icons/fa";
-// 更新紙箱資料表單元件
-import UpdateBoxForm from "../form/UpdateBoxForm";
+// 更新紙箱、刪除紙箱資料表單元件
+import UpdateBoxDialog from "../dialog/UpdateBoxDialog";
+import DeleteBoxDialog from "../dialog/DeleteBoxDialog";
 
 // 表格內客製化樣式 (或建立style.css覆蓋樣式)
 const customStyles = {
@@ -115,41 +105,8 @@ const AdminDeprecatedTable = () => {
       name: "編輯",
       selector: (row) => (
         <div className="flex gap-2">
-          <Dialog>
-            <DialogTrigger asChild>
-              <button className="rounded-md bg-main-600 p-2 text-white hover:bg-main-500 focus-visible:outline-none">
-                <FaPen />
-              </button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-[500px]">
-              <DialogHeader>
-                <DialogTitle>編輯紙箱</DialogTitle>
-                <DialogDescription>編輯紙箱資訊</DialogDescription>
-              </DialogHeader>
-              <div className="flex gap-2">
-                <img src={row.image_url} alt="照片" className="w-1/4" />
-                <div className="flex flex-col">
-                  <p>紙箱編號：{row.id}</p>
-                  <p>
-                    新增時間：{row.created_at.replace("T", " ").slice(0, 16)}
-                  </p>
-                  <p>
-                    更新時間：{row.updated_at.replace("T", " ").slice(0, 16)}
-                  </p>
-                  <p className="text-red-500">
-                    保存到期日：{row.updated_at.replace("T", " ").slice(0, 16)}
-                  </p>
-                  <p className="text-red-500">
-                    回收會員：{row.user_id.slice(0, 16)}
-                  </p>
-                </div>
-              </div>
-              <UpdateBoxForm row={row} />
-            </DialogContent>
-          </Dialog>
-          <button className="rounded-md bg-red-600 p-2 text-white hover:bg-red-500 focus-visible:outline-none">
-            <FaTrashAlt />
-          </button>
+          <UpdateBoxDialog row={row} />
+          <DeleteBoxDialog row={row} />
         </div>
       ),
     },

--- a/src/components/ui/dialog.jsx
+++ b/src/components/ui/dialog.jsx
@@ -1,84 +1,94 @@
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Dialog = DialogPrimitive.Root
+const Dialog = DialogPrimitive.Root;
 
-const DialogTrigger = DialogPrimitive.Trigger
+const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = DialogPrimitive.Portal
+const DialogPortal = DialogPrimitive.Portal;
 
-const DialogClose = DialogPrimitive.Close
+const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
     )}
-    {...props} />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DialogContent = React.forwardRef(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
-      )}
-      {...props}>
-      {children}
-      <DialogPrimitive.Close
-        className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
+const DialogContent = React.forwardRef(
+  ({ className, children, ...props }, ref) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  ),
+);
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const DialogHeader = ({
-  className,
-  ...props
-}) => (
+const DialogHeader = ({ className, ...props }) => (
   <div
-    className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
-    {...props} />
-)
-DialogHeader.displayName = "DialogHeader"
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
 
-const DialogFooter = ({
-  className,
-  ...props
-}) => (
+const DialogFooter = ({ className, ...props }) => (
   <div
-    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
-    {...props} />
-)
-DialogFooter.displayName = "DialogFooter"
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
-    {...props} />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
     className={cn("text-sm text-muted-foreground", className)}
-    {...props} />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
@@ -91,4 +101,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-}
+};

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -85,7 +85,7 @@ export function useUpdateBox() {
     mutationFn: ({ boxId, values }) => apiUpdateBox(boxId, values),
     onSuccess: () => {
       toast.success("更新成功");
-      queryClient.invalidateQueries({ queryKey: ["boxes", "managing"] });
+      queryClient.invalidateQueries({ queryKey: ["boxes"] });
     },
     onError: (error) => {
       toast.error(error.message);

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -81,6 +81,7 @@ export function useUpdateBox() {
     mutate: updateBox,
     error: updatedError,
     isPending: isUpdating,
+    isError,
   } = useMutation({
     mutationFn: ({ boxId, values }) => apiUpdateBox(boxId, values),
     onSuccess: () => {
@@ -91,5 +92,5 @@ export function useUpdateBox() {
       toast.error(error.message);
     },
   });
-  return { updateBox, updatedError, isUpdating };
+  return { updateBox, updatedError, isUpdating, isError };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -151,6 +151,12 @@
   .btn {
     @apply rounded-[20px] border border-[#563B28] bg-main-600 px-5 py-2 text-main-200 shadow-[0_2px_0_#563B28] hover:bg-main-500;
   }
+  .btn-cancel {
+    @apply rounded-[20px] border border-[#D9D9D9] bg-neutral-600 px-5 py-2 text-neutral-200 shadow-[0_2px_0_#D9D9D9] hover:bg-neutral-500;
+  }
+  .btn-delete {
+    @apply rounded-[20px] border border-red-300 bg-red-600 px-5 py-2 text-neutral-200 shadow-[0_2px_0_#fca5a5] hover:bg-red-500;
+  }
 }
 
 @layer base {

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -23,7 +23,7 @@ export async function apiGetBoxesForSelling() {
     return boxes;
   } catch (error) {
     // supabase 錯誤內容
-    console.error(error);
+    console.error("讀取 Box 發生錯誤:", error);
     // UI 顯示的錯誤內容
     throw new Error("無法取得 boxes 資料，請稍後再試");
   }
@@ -51,7 +51,7 @@ export async function apiGetBoxesForAdminManaging() {
     return boxes;
   } catch (error) {
     // supabase 錯誤內容
-    console.error(error);
+    console.error("讀取 Box 發生錯誤:", error);
     // UI 顯示的錯誤內容
     throw new Error("無法取得 boxes 資料，請稍後再試");
   }
@@ -79,7 +79,7 @@ export async function apiGetBoxesForScraping() {
     return boxes;
   } catch (error) {
     // supabase 錯誤內容
-    console.error(error);
+    console.error("讀取 Box 發生錯誤:", error);
     // UI 顯示的錯誤內容
     throw new Error("無法取得 boxes 資料，請稍後再試");
   }
@@ -103,17 +103,14 @@ export async function apiUpdateBox(boxId, values) {
       .update({ ...values, updated_at: getTimestamp() })
       .eq("id", boxId)
       .select();
+
     if (error) {
-      console.log(error);
+      console.error(error);
       throw error;
     }
-    if (!box) throw new Error("更新失敗，請檢查 ID 是否正確");
-
     return box;
   } catch (error) {
-    // supabase 錯誤內容
-    console.error(error);
-    // UI 顯示的錯誤內容
-    throw new Error("無法更新 boxes 資料，請稍後再試");
+    console.error(`更新 BoxID: ${boxId} 失敗:`, error);
+    throw new Error("無法更新資料，請確認網路狀態或稍後再試");
   }
 }

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -1,4 +1,5 @@
 import supabase from "./supabase";
+import { getTimestamp } from "@/utils/helpers";
 
 /**
  * 從 Supabase 取得紙箱狀態為可認領的紙箱資料
@@ -99,10 +100,13 @@ export async function apiUpdateBox(boxId, values) {
   try {
     const { data: box, error } = await supabase
       .from("boxes")
-      .update({ ...values, updated_at: new Date() })
+      .update({ ...values, updated_at: getTimestamp() })
       .eq("id", boxId)
       .select();
-    if (error) throw error;
+    if (error) {
+      console.log(error);
+      throw error;
+    }
     if (!box) throw new Error("更新失敗，請檢查 ID 是否正確");
 
     return box;


### PR DESCRIPTION
### **背景**
- 解決 5-3、5-4 列表編輯紙箱API 錯誤、並調整 5-3、5-4 結構

### **主要修改**
- 調整：5-3、5-4 列表資料讀取
  - 調整 columns 內容，避免資料讀取完成前出現渲染錯誤（白畫面）
  
- 新增：5-3、5-4 編輯按鈕Dialog 單獨拆分成 `UpdateBoxDialog.jsx`元件，並且更新 編輯表單`UpdateBoxForm.jsx`元件
  -  點擊提交資料後，Dialog自動關閉，並提示更新成功（已串接更新紙箱API）
  -  點擊取消按鈕時，Dialog自動關閉，並提示取消更新

- 新增：5-3、5-4 刪除按鈕Dialog 單獨拆分成 `DeleteBoxDialog.jsx`元件
  -  點擊刪除按鈕時，Dialog自動關閉，並提示刪除成功（尚未串接刪除API）
  - 點擊取消按鈕時，Dialog自動關閉，並提示取消刪除

- 調整：`useUpdateBox` hook 函數
  - 更新紙箱資料成功後，只要包含 `queryKey: ["boxes"]` 的query都會無效並重新更新列表

### **測試方式**
- [ ] 呼叫 `useUpdateBox` hook
  - [ ] 是否能更新紙箱資料，並提示更新成功？
  - [ ] 編輯dialog 關閉後，列表資料是否有即時更新在畫面上？

issue #10 