### PR TITLE
Feature: 新增 5-1回收站點管理者後台 - 回收站管理者資訊頁

### DIFF
--- a/src/components/AdminInfo.jsx
+++ b/src/components/AdminInfo.jsx
@@ -21,8 +21,8 @@ const totalBoxes = function (boxes) {
 };
 
 function AdminInfo() {
-  const { station, isLoadingStation } = useStation(1);
-  const { boxes, isLoadingBoxes } = useBoxesTotalForSelling(1);
+  const { station, isLoadingStation } = useStation(10);
+  const { boxes, isLoadingBoxes } = useBoxesTotalForSelling(10);
   if (isLoadingStation) return <Spinner />;
   if (isLoadingBoxes) return <Spinner />;
   const result = totalBoxes(boxes);

--- a/src/components/AdminInfo.jsx
+++ b/src/components/AdminInfo.jsx
@@ -1,18 +1,55 @@
 import { useStation } from "@/hooks/useStation";
 import AdminInfoForm from "./form/AdminInfoForm";
 import Spinner from "./Spinner";
+import AdminRecyclingBoxForm from "./form/AdminRecyclingBoxForm";
+import { useBoxesTotalForSelling } from "@/hooks/useBoxes";
+import SellingBoxesCard from "./card/SellingBoxesCard";
+
+const totalBoxes = function (boxes) {
+  let small = 0;
+  let medium = 0;
+  let large = 0;
+  let extraLarge = 0;
+  if (boxes.length === 0) return { small, medium, large, extraLarge };
+  for (let i = 0; i < boxes.length; i++) {
+    if (boxes[i].size === "小") small++;
+    if (boxes[i].size === "中") medium++;
+    if (boxes[i].size === "大") large++;
+    if (boxes[i].size === "特大") extraLarge++;
+  }
+  return { small, medium, large, extraLarge };
+};
 
 function AdminInfo() {
   const { station, isLoadingStation } = useStation(1);
+  const { boxes, isLoadingBoxes } = useBoxesTotalForSelling(1);
   if (isLoadingStation) return <Spinner />;
+  if (isLoadingBoxes) return <Spinner />;
+  const result = totalBoxes(boxes);
+
   return (
     <>
       <div className="my-20 bg-main-100 px-3 py-10 sm:rounded-3xl sm:px-10">
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-6 md:flex-row">
           <div className="rounded-2xl bg-white p-4 md:w-1/2 lg:p-10">
             <AdminInfoForm station={station} />
           </div>
-          <div className="flex flex-col gap-6"></div>
+          <div className="flex flex-col gap-6 md:w-1/2">
+            <div className="rounded-[8px] bg-white p-4">
+              <AdminRecyclingBoxForm station={station} />
+            </div>
+            <div className="rounded-[8px] bg-white p-4">
+              <div className="mb-2 rounded-md bg-second-100 py-1">
+                <p className="fs-6 text-center text-second-400">可認領紙箱</p>
+              </div>
+              <div className="flex gap-2">
+                <SellingBoxesCard size="小" count={result.small} />
+                <SellingBoxesCard size="中" count={result.medium} />
+                <SellingBoxesCard size="大" count={result.large} />
+                <SellingBoxesCard size="特大" count={result.extraLarge} />
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </>

--- a/src/components/AdminInfo.jsx
+++ b/src/components/AdminInfo.jsx
@@ -1,48 +1,16 @@
-import { Button } from "./ui/button";
-
 import { useStation } from "@/hooks/useStation";
-import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
-import { useUpdateAvailableSlots } from "@/hooks/useUpdateAvailableSlots";
-import { getTimestamp } from "@/utils/helpers";
-
+import AdminInfoForm from "./form/AdminInfoForm";
 import Spinner from "./Spinner";
 
-import AdminInfoForm from "./form/AdminInfoForm";
-import MemberInfoForm from "./form/MemberInfoForm";
-
-const style = {
-  cardContainer: "flex items-center justify-around rounded-2xl bg-white p-10",
-  cardText: "text-2xl font-bold",
-  cardNumber: "text-6xl font-bold text-main-600",
-};
-
 function AdminInfo() {
-  const { station, isLoadingStation, stationError } = useStation(1);
-  const { updateStation, isUpdating } = useUpdateStationInfo();
-  const { updateAvailableSlots, isLoading } = useUpdateAvailableSlots();
-
+  const { station, isLoadingStation } = useStation(1);
   if (isLoadingStation) return <Spinner />;
-
-  const {
-    id,
-    station_name,
-    address,
-    phone,
-    image_url,
-    station_daily_hours,
-    pending_boxes_xl,
-    pending_boxes_l,
-    pending_boxes_m,
-    pending_boxes_s,
-    available_slots,
-  } = station;
-
   return (
     <>
       <div className="my-20 bg-main-100 px-3 py-10 sm:rounded-3xl sm:px-10">
         <div className="flex flex-col gap-6">
           <div className="rounded-2xl bg-white p-4 md:w-1/2 lg:p-10">
-            <AdminInfoForm />
+            <AdminInfoForm station={station} />
           </div>
           <div className="flex flex-col gap-6"></div>
         </div>
@@ -50,6 +18,4 @@ function AdminInfo() {
     </>
   );
 }
-``;
-
 export default AdminInfo;

--- a/src/components/AdminInfo.jsx
+++ b/src/components/AdminInfo.jsx
@@ -7,6 +7,15 @@ import { getTimestamp } from "@/utils/helpers";
 
 import Spinner from "./Spinner";
 
+import AdminInfoForm from "./form/AdminInfoForm";
+import MemberInfoForm from "./form/MemberInfoForm";
+
+const style = {
+  cardContainer: "flex items-center justify-around rounded-2xl bg-white p-10",
+  cardText: "text-2xl font-bold",
+  cardNumber: "text-6xl font-bold text-main-600",
+};
+
 function AdminInfo() {
   const { station, isLoadingStation, stationError } = useStation(1);
   const { updateStation, isUpdating } = useUpdateStationInfo();
@@ -29,70 +38,16 @@ function AdminInfo() {
   } = station;
 
   return (
-    <div>
-      5-2 回收站點回收資訊總覽
-      <div className="my-6">
-        <Button
-          onClick={() =>
-            updateStation({
-              id: 1,
-              address: "新北市三重區大同南路152號1樓",
-              phone: "+886-2-2975970",
-              updated_at: getTimestamp(),
-              station_daily_hours: [
-                {
-                  id: 7,
-                  open_time: `05:00:00+00`,
-                  close_time: `21:00:00+00`,
-                  updated_at: getTimestamp(),
-                },
-              ],
-            })
-          }
-          disabled={isUpdating}
-        >
-          更新站點基本資訊
-        </Button>
-        <Button
-          className="ms-4"
-          onClick={() => {
-            updateAvailableSlots({
-              stationId: station.id,
-              xlCounts: 0,
-              lCounts: 0,
-              mCounts: 0,
-              sCounts: 10,
-            });
-          }}
-        >
-          更新站點可回收紙箱數量
-        </Button>
-      </div>
-      <div>
-        <p>店名：{station_name}</p>
-        <p>地址：{address}</p>
-        <p>電話：{phone}</p>
-        <div>
-          營業時間：
-          <ul className="ms-5 list-disc ps-5">
-            {station_daily_hours.map((el) => (
-              <li key={el.id}>
-                id：{el.id} / 星期：
-                {el.day_of_week === 0 ? 7 : el.day_of_week}：{el.open_time}
-              </li>
-            ))}
-          </ul>
+    <>
+      <div className="my-20 bg-main-100 px-3 py-10 sm:rounded-3xl sm:px-10">
+        <div className="flex flex-col gap-6">
+          <div className="rounded-2xl bg-white p-4 md:w-1/2 lg:p-10">
+            <AdminInfoForm />
+          </div>
+          <div className="flex flex-col gap-6"></div>
         </div>
-        <p>可認領紙箱數量 XL：{pending_boxes_xl}</p>
-        <p>可認領紙箱數量 L：{pending_boxes_l}</p>
-        <p>可認領紙箱數量 M：{pending_boxes_m}</p>
-        <p>可認領紙箱數量 S：{pending_boxes_s}</p>
-        <p>可回收紙箱空位數 XL：{available_slots.XL}</p>
-        <p>可回收紙箱空位數 L：{available_slots.L}</p>
-        <p>可回收紙箱空位數 M：{available_slots.M}</p>
-        <p>可回收紙箱空位數 S：{available_slots.S}</p>
       </div>
-    </div>
+    </>
   );
 }
 ``;

--- a/src/components/AdminNav.jsx
+++ b/src/components/AdminNav.jsx
@@ -1,5 +1,0 @@
-function AdminNav() {
-  return <div>站點管理員切分頁元件</div>;
-}
-
-export default AdminNav;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -14,7 +14,7 @@ const style = {
 
 function Header() {
   return (
-    <div className="bg-[rgba(255,255,255,0.75)]">
+    <header className="bg-[rgba(255,255,255,0.75)]">
       <div className={style.container}>
         <Link to="/">
           <picture>
@@ -48,7 +48,7 @@ function Header() {
           </NavLink>
         </nav>
       </div>
-    </div>
+    </header>
   );
 }
 

--- a/src/components/MemberBanner.jsx
+++ b/src/components/MemberBanner.jsx
@@ -3,10 +3,24 @@ import memberBannerBg01 from "@/assets/memberBanner-bg1.svg";
 import box from "@/assets/box.svg";
 import dialog from "@/assets/dialog.svg";
 import { FaStoreAlt } from "react-icons/fa";
+import { useLocation } from "react-router-dom";
 
 function MemberBanner() {
+  const location = useLocation();
+
+  const getNavType = () => {
+    if (location.pathname.startsWith("/member/normal")) {
+      return "normal";
+    } else if (location.pathname.startsWith("/member/admin")) {
+      return "admin";
+    } else {
+      return "normal"; // 預設值
+    }
+  };
+
+  const navType = getNavType();
   return (
-    <div className="bg-[#F3F3F3] bg-top bg-no-repeat md:bg-[url('@/assets/memberBanner-bg2.svg')]">
+    <section className="bg-[#F3F3F3] bg-top bg-no-repeat md:bg-[url('@/assets/memberBanner-bg2.svg')]">
       <div className="container relative mx-auto flex flex-col items-center gap-10 py-20 text-center md:flex-row md:justify-between md:text-left">
         <div className="relative h-[201px] w-[200px]">
           <img src={avatorLg} alt="會員頭像" className="absolute z-10" />
@@ -16,22 +30,11 @@ function MemberBanner() {
             className="absolute -bottom-3 -left-14 hidden md:flex"
           />
         </div>
-        <div className="grow">
-          <h2 className="mb-4 text-black">Natasa</h2>
-          <div className="fs-6 mb-4 flex flex-col gap-1 text-[#6F6F6F]">
-            <p>會員編號：Natasa1234</p>
-            <p>電子信箱：ntasa0101@gmail.com</p>
-            <p>連絡電話：0934134165</p>
-          </div>
-          <button className="btn flex items-center gap-1 text-main-200">
-            <FaStoreAlt className="text-white" />
-            申請成為轉運站站長
-          </button>
-        </div>
+        {navType === "normal" ? <NormalBanner /> : <AdminBanner />}
         <div className="relative h-60 w-80 md:w-[500px]">
           <h4 className="absolute left-12 top-6 z-30 rotate-6 text-nowrap text-center text-main-100 lg:left-48 lg:top-16">
-            箱村村長午安，
-            <br /> 歡迎來到返箱轉運站！
+            {navType === "normal" ? "箱村村長" : "站長"}午安，
+            <br /> 歡迎{navType === "normal" ? "來到" : "回到"}返箱轉運站！
           </h4>
           <img
             src={dialog}
@@ -41,8 +44,38 @@ function MemberBanner() {
           <img src={box} alt="紙箱" className="absolute top-24 z-10" />
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
 export default MemberBanner;
+
+function NormalBanner() {
+  return (
+    <div className="grow">
+      <h2 className="mb-4 text-black">Natasa</h2>
+      <div className="fs-6 mb-4 flex flex-col gap-1 text-[#6F6F6F]">
+        <p>會員編號：Natasa1234</p>
+        <p>電子信箱：ntasa0101@gmail.com</p>
+        <p>連絡電話：0934134165</p>
+      </div>
+      <button className="btn flex items-center gap-1 text-main-200">
+        <FaStoreAlt className="text-white" />
+        申請成為轉運站站長
+      </button>
+    </div>
+  );
+}
+
+function AdminBanner() {
+  return (
+    <div className="grow">
+      <h2 className="mb-4 text-black">塔塔拉的甜點工作室</h2>
+      <div className="fs-6 mb-4 flex flex-col gap-1 text-[#6F6F6F]">
+        <p>地址：741009台南市善化區陽光大道210號</p>
+        <p>連絡電話：0965566758</p>
+        <p>營業時間：周一至周五 10:00 - 20:00</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MemberNav.jsx
+++ b/src/components/MemberNav.jsx
@@ -29,8 +29,8 @@ function MemberNav() {
   const navType = getNavType();
 
   return (
-    <>
-      <div className="bg-[#F3F3F3]">
+    <main>
+      <nav className="bg-[#F3F3F3]">
         {/* TabTrigger */}
         <div className={style.mainNavContainer}>
           <NavLink
@@ -50,18 +50,18 @@ function MemberNav() {
             <h4>管理者頁面</h4>
           </NavLink>
         </div>
-      </div>
+      </nav>
       {navType === "normal" ? <NormalNav /> : <AdminNav />}
-      <div className="container mx-auto">
+      <section className="container mx-auto">
         <Outlet />
-      </div>
-    </>
+      </section>
+    </main>
   );
 }
 
 function NormalNav() {
   return (
-    <div className="bg-white">
+    <nav className="bg-white">
       <div className={style.secondNavContainer}>
         <NavLink
           to="normal/memberInfo"
@@ -88,13 +88,13 @@ function NormalNav() {
           <h4>交易紀錄</h4>
         </NavLink>
       </div>
-    </div>
+    </nav>
   );
 }
 
 function AdminNav() {
   return (
-    <div className="bg-white">
+    <nav className="bg-white">
       <div className={style.secondNavContainer}>
         <NavLink
           to="admin/adminInfo"
@@ -129,7 +129,7 @@ function AdminNav() {
           <h4>交易紀錄</h4>
         </NavLink>
       </div>
-    </div>
+    </nav>
   );
 }
 export default MemberNav;

--- a/src/components/card/SellingBoxesCard.jsx
+++ b/src/components/card/SellingBoxesCard.jsx
@@ -1,0 +1,16 @@
+import PropTypes from "prop-types";
+SellingBoxesCard.propTypes = {
+  size: PropTypes.string,
+  count: PropTypes.number,
+};
+
+function SellingBoxesCard({ size, count }) {
+  return (
+    <div className="flex w-1/4 flex-col gap-1 rounded-md bg-second-100 p-2 text-center text-second-400">
+      <h4>{count}</h4>
+      <p className="fs-7">{size}紙箱</p>
+    </div>
+  );
+}
+
+export default SellingBoxesCard;

--- a/src/components/form/AdminInfoForm.jsx
+++ b/src/components/form/AdminInfoForm.jsx
@@ -1,6 +1,7 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
+import PropTypes from "prop-types";
 
 import {
   Form,
@@ -13,31 +14,32 @@ import {
 import { Input } from "@/components/ui/input";
 import { FaPen, FaTimes } from "react-icons/fa";
 import { useState } from "react";
-import { useStation } from "@/hooks/useStation";
+import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
 
 const formSchema = z.object({
   station_name: z.string().nonempty("站點名稱不得為空"),
   address: z.string().nonempty("地址不得為空"),
-  phone: z
-    .string()
-    .nonempty("電話不得為空")
-    .regex(/^09\d{8}$/, "請輸入正確的台灣手機號碼"),
+  phone: z.string().nonempty("電話不得為空"),
 });
 
-export default function MyForm() {
-  useStation();
+AdminInfoForm.propTypes = { station: PropTypes.object };
+
+function AdminInfoForm({ station }) {
   const [isEditing, setIsEditing] = useState(false);
+  const { updateStation } = useUpdateStationInfo();
   const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      station_name: "",
-      address: "",
-      phone: "",
+      station_name: station.station_name,
+      address: station.address,
+      phone: station.phone,
     },
   });
+
   function onSubmit(values) {
     try {
       console.log(values);
+      updateStation(values);
     } catch (error) {
       console.error("Form submission error", error);
     }
@@ -71,6 +73,7 @@ export default function MyForm() {
                 <FormControl>
                   <Input
                     placeholder="請輸入站點名稱"
+                    value={station.station_name}
                     type="text"
                     {...field}
                     disabled={!isEditing}
@@ -93,6 +96,7 @@ export default function MyForm() {
                 <FormControl>
                   <Input
                     placeholder="請輸入站點地址"
+                    value={station.address}
                     type="text"
                     {...field}
                     disabled={!isEditing}
@@ -115,6 +119,7 @@ export default function MyForm() {
                 <FormControl>
                   <Input
                     placeholder="請輸入電話號碼"
+                    value={station.phone}
                     type="text"
                     {...field}
                     disabled={!isEditing}
@@ -135,3 +140,5 @@ export default function MyForm() {
     </>
   );
 }
+
+export default AdminInfoForm;

--- a/src/components/form/AdminInfoForm.jsx
+++ b/src/components/form/AdminInfoForm.jsx
@@ -1,0 +1,137 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { FaPen, FaTimes } from "react-icons/fa";
+import { useState } from "react";
+import { useStation } from "@/hooks/useStation";
+
+const formSchema = z.object({
+  station_name: z.string().nonempty("站點名稱不得為空"),
+  address: z.string().nonempty("地址不得為空"),
+  phone: z
+    .string()
+    .nonempty("電話不得為空")
+    .regex(/^09\d{8}$/, "請輸入正確的台灣手機號碼"),
+});
+
+export default function MyForm() {
+  useStation();
+  const [isEditing, setIsEditing] = useState(false);
+  const form = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      station_name: "",
+      address: "",
+      phone: "",
+    },
+  });
+  function onSubmit(values) {
+    try {
+      console.log(values);
+    } catch (error) {
+      console.error("Form submission error", error);
+    }
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <p className="text-2xl font-bold text-gray-700">轉運站長</p>
+        <button type="button" onClick={() => setIsEditing(!isEditing)}>
+          {isEditing ? (
+            <FaTimes size={20} />
+          ) : (
+            <FaPen className="text-main-600" size={20} />
+          )}
+        </button>
+      </div>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="mx-auto max-w-3xl space-y-4 py-6"
+        >
+          <FormField
+            control={form.control}
+            name="station_name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  <h6 className="text-gray-700">站點名稱</h6>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="請輸入站點名稱"
+                    type="text"
+                    {...field}
+                    disabled={!isEditing}
+                  />
+                </FormControl>
+
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="address"
+            render={({ field }) => (
+              <FormItem className="mt-6">
+                <FormLabel>
+                  <h6 className="text-gray-700">地址</h6>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="請輸入站點地址"
+                    type="text"
+                    {...field}
+                    disabled={!isEditing}
+                  />
+                </FormControl>
+
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="phone"
+            render={({ field }) => (
+              <FormItem className="mt-6">
+                <FormLabel>
+                  <h6 className="text-gray-700">電話</h6>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="請輸入電話號碼"
+                    type="text"
+                    {...field}
+                    disabled={!isEditing}
+                  />
+                </FormControl>
+
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          {isEditing && (
+            <button className="btn" type="submit">
+              確認修改
+            </button>
+          )}
+        </form>
+      </Form>
+    </>
+  );
+}

--- a/src/components/form/AdminInfoForm.jsx
+++ b/src/components/form/AdminInfoForm.jsx
@@ -1,7 +1,8 @@
 import { useForm } from "react-hook-form";
+import { useState } from "react";
+import toast from "react-hot-toast";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
-import PropTypes from "prop-types";
 
 import {
   Form,
@@ -13,7 +14,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { FaPen, FaTimes } from "react-icons/fa";
-import { useState } from "react";
 import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
 
 const formSchema = z.object({
@@ -22,26 +22,28 @@ const formSchema = z.object({
   phone: z.string().nonempty("電話不得為空"),
 });
 
+import PropTypes from "prop-types";
 AdminInfoForm.propTypes = { station: PropTypes.object };
 
 function AdminInfoForm({ station }) {
   const [isEditing, setIsEditing] = useState(false);
-  const { updateStation } = useUpdateStationInfo();
+  const { updateStation, isUpdating } = useUpdateStationInfo();
+
   const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      station_name: station.station_name,
-      address: station.address,
-      phone: station.phone,
+      station_name: station.station_name || "",
+      address: station.address || "",
+      phone: station.phone || "",
     },
   });
 
   function onSubmit(values) {
     try {
       console.log(values);
-      updateStation(values);
+      updateStation({ ...values });
     } catch (error) {
-      console.error("Form submission error", error);
+      toast.error("Form submission error", error);
     }
   }
 
@@ -131,8 +133,8 @@ function AdminInfoForm({ station }) {
             )}
           />
           {isEditing && (
-            <button className="btn" type="submit">
-              確認修改
+            <button className="btn" type="submit" disabled={isUpdating}>
+              {isUpdating ? "更新中" : "確認修改"}
             </button>
           )}
         </form>

--- a/src/components/form/AdminRecyclingBoxForm.jsx
+++ b/src/components/form/AdminRecyclingBoxForm.jsx
@@ -2,28 +2,31 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 import { FaPen, FaTimes } from "react-icons/fa";
+import { useUpdateAvailableSlots } from "@/hooks/useUpdateAvailableSlots";
 
 import PropTypes from "prop-types";
 AdminRecyclingBoxForm.propTypes = { station: PropTypes.object };
 
 function AdminRecyclingBoxForm({ station }) {
+  const { updateAvailableSlots, isLoading } = useUpdateAvailableSlots();
   const [isEditing, setIsEditing] = useState(false);
   const form = useForm({
     defaultValues: {
-      小: station.pending_boxes_s || 0,
-      中: station.pending_boxes_m || 0,
-      大: station.pending_boxes_l || 0,
-      特大: station.pending_boxes_xl || 0,
+      S: station.available_slots?.S || 0,
+      M: station.available_slots?.M || 0,
+      L: station.available_slots?.L || 0,
+      XL: station.available_slots?.XL || 0,
     },
   });
   const { register, handleSubmit } = form;
 
-  function onSubmit(values) {
+  function onSubmit(available_slots) {
     try {
-      console.log(values);
-      toast.success("已更新紙箱數量");
+      console.log({ stationId: station.id, ...available_slots });
+      updateAvailableSlots({ stationId: station.id, ...available_slots });
+      toast.success("提交成功");
     } catch (error) {
-      toast.error("Form submission error", error);
+      toast.error("提交失敗", error);
     }
   }
   return (
@@ -49,10 +52,10 @@ function AdminRecyclingBoxForm({ station }) {
           <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
             <input
               type="text"
-              name="小"
+              name="S"
               defaultValue={20}
               disabled={!isEditing}
-              {...register("小", { valueAsNumber: true })}
+              {...register("S", { valueAsNumber: true })}
               className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
             />
             <label className="fs-7">小紙箱</label>
@@ -60,10 +63,10 @@ function AdminRecyclingBoxForm({ station }) {
           <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
             <input
               type="text"
-              name="中"
+              name="M"
               defaultValue={20}
               disabled={!isEditing}
-              {...register("中", { valueAsNumber: true })}
+              {...register("M", { valueAsNumber: true })}
               className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
             />
             <label className="fs-7">中紙箱</label>
@@ -71,10 +74,10 @@ function AdminRecyclingBoxForm({ station }) {
           <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
             <input
               type="text"
-              name="大"
+              name="L"
               defaultValue={20}
               disabled={!isEditing}
-              {...register("大", { valueAsNumber: true })}
+              {...register("L", { valueAsNumber: true })}
               className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
             />
             <label className="fs-7">大紙箱</label>
@@ -82,18 +85,18 @@ function AdminRecyclingBoxForm({ station }) {
           <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
             <input
               type="text"
-              name="特大"
+              name="XL"
               defaultValue={20}
               disabled={!isEditing}
-              {...register("特大", { valueAsNumber: true })}
+              {...register("XL", { valueAsNumber: true })}
               className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
             />
             <label className="fs-7">特大紙箱</label>
           </div>
         </div>
         {isEditing && (
-          <button className="btn" type="submit">
-            確認修改
+          <button className="btn" type="submit" disabled={isLoading}>
+            {isLoading ? "更新中" : "確認修改"}
           </button>
         )}
       </form>

--- a/src/components/form/AdminRecyclingBoxForm.jsx
+++ b/src/components/form/AdminRecyclingBoxForm.jsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import toast from "react-hot-toast";
+import { FaPen, FaTimes } from "react-icons/fa";
+
+import PropTypes from "prop-types";
+AdminRecyclingBoxForm.propTypes = { station: PropTypes.object };
+
+function AdminRecyclingBoxForm({ station }) {
+  const [isEditing, setIsEditing] = useState(false);
+  const form = useForm({
+    defaultValues: {
+      小: station.pending_boxes_s || 0,
+      中: station.pending_boxes_m || 0,
+      大: station.pending_boxes_l || 0,
+      特大: station.pending_boxes_xl || 0,
+    },
+  });
+  const { register, handleSubmit } = form;
+
+  function onSubmit(values) {
+    try {
+      console.log(values);
+      toast.success("已更新紙箱數量");
+    } catch (error) {
+      toast.error("Form submission error", error);
+    }
+  }
+  return (
+    <>
+      <div className="mb-2 flex">
+        <button
+          type="button"
+          onClick={() => setIsEditing(!isEditing)}
+          className="ml-auto"
+        >
+          {isEditing ? (
+            <FaTimes size={20} />
+          ) : (
+            <FaPen className="text-main-600" size={20} />
+          )}
+        </button>
+      </div>
+      <div className="mb-2 rounded-md bg-main-100 py-1">
+        <p className="fs-6 text-center text-main-600">可回收紙箱</p>
+      </div>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div className="mb-2 flex gap-2">
+          <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
+            <input
+              type="text"
+              name="小"
+              defaultValue={20}
+              disabled={!isEditing}
+              {...register("小", { valueAsNumber: true })}
+              className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
+            />
+            <label className="fs-7">小紙箱</label>
+          </div>
+          <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
+            <input
+              type="text"
+              name="中"
+              defaultValue={20}
+              disabled={!isEditing}
+              {...register("中", { valueAsNumber: true })}
+              className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
+            />
+            <label className="fs-7">中紙箱</label>
+          </div>
+          <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
+            <input
+              type="text"
+              name="大"
+              defaultValue={20}
+              disabled={!isEditing}
+              {...register("大", { valueAsNumber: true })}
+              className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
+            />
+            <label className="fs-7">大紙箱</label>
+          </div>
+          <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
+            <input
+              type="text"
+              name="特大"
+              defaultValue={20}
+              disabled={!isEditing}
+              {...register("特大", { valueAsNumber: true })}
+              className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
+            />
+            <label className="fs-7">特大紙箱</label>
+          </div>
+        </div>
+        {isEditing && (
+          <button className="btn" type="submit">
+            確認修改
+          </button>
+        )}
+      </form>
+    </>
+  );
+}
+
+export default AdminRecyclingBoxForm;

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -77,7 +77,7 @@ const AdminBoxManageTable = () => {
   // );
 
   // 取得可認領紙箱資料
-  const { boxes, isLoadingBoxes, boxesError } = useBoxesForAdminManaging();
+  const { boxes, isLoadingBoxes, boxesError } = useBoxesForAdminManaging(10);
   if (isLoadingBoxes) return <Spinner />;
   if (boxesError) return <ErrorMessage errorMessage={boxesError.message} />;
 
@@ -86,13 +86,13 @@ const AdminBoxManageTable = () => {
     { name: "紙箱編號", selector: (row) => row.id, sortable: true },
     {
       name: "新增時間",
-      selector: (row) => row.created_at.replace("T", " ").slice(0, 16),
+      selector: (row) => row.created_at?.replace("T", " ").slice(0, 16),
       sortable: true,
       width: "140px",
     },
     {
       name: "更新時間",
-      selector: (row) => row.updated_at.replace("T", " ").slice(0, 16),
+      selector: (row) => row.updated_at?.replace("T", " ").slice(0, 16),
       sortable: true,
       width: "140px",
     },
@@ -132,17 +132,15 @@ const AdminBoxManageTable = () => {
                 <div className="flex flex-col">
                   <p>紙箱編號：{row.id}</p>
                   <p>
-                    新增時間：{row.created_at.replace("T", " ").slice(0, 16)}
+                    新增時間：{row.created_at?.replace("T", " ").slice(0, 16)}
                   </p>
                   <p>
-                    更新時間：{row.updated_at.replace("T", " ").slice(0, 16)}
+                    更新時間：{row.updated_at?.replace("T", " ").slice(0, 16)}
                   </p>
                   <p className="text-red-500">
-                    保存到期日：{row.updated_at.replace("T", " ").slice(0, 16)}
+                    保存到期日：{row.updated_at?.replace("T", " ").slice(0, 16)}
                   </p>
-                  <p className="text-red-500">
-                    回收會員：{row.user_id.slice(0, 16)}
-                  </p>
+                  <p className="text-red-500">回收會員：{row.user_id}</p>
                 </div>
               </div>
               <UpdateBoxForm row={row} />

--- a/src/components/table/AdminDeprecatedTable.jsx
+++ b/src/components/table/AdminDeprecatedTable.jsx
@@ -76,7 +76,7 @@ const AdminDeprecatedTable = () => {
   // );
 
   // 取得報廢紙箱資料
-  const { boxes, isLoadingBoxes, boxesError } = useBoxesForScraping();
+  const { boxes, isLoadingBoxes, boxesError } = useBoxesForScraping(10);
   if (isLoadingBoxes) return <Spinner />;
   if (boxesError) return <ErrorMessage errorMessage={boxesError.message} />;
 
@@ -85,13 +85,13 @@ const AdminDeprecatedTable = () => {
     { name: "紙箱編號", selector: (row) => row.id, sortable: true },
     {
       name: "新增時間",
-      selector: (row) => row.created_at.replace("T", " ").slice(0, 16),
+      selector: (row) => row.created_at?.replace("T", " ").slice(0, 16),
       sortable: true,
       width: "140px",
     },
     {
       name: "更新時間",
-      selector: (row) => row.updated_at.replace("T", " ").slice(0, 16),
+      selector: (row) => row.updated_at?.replace("T", " ").slice(0, 16),
       sortable: true,
       width: "140px",
     },
@@ -131,17 +131,15 @@ const AdminDeprecatedTable = () => {
                 <div className="flex flex-col">
                   <p>紙箱編號：{row.id}</p>
                   <p>
-                    新增時間：{row.created_at.replace("T", " ").slice(0, 16)}
+                    新增時間：{row.created_at?.replace("T", " ").slice(0, 16)}
                   </p>
                   <p>
-                    更新時間：{row.updated_at.replace("T", " ").slice(0, 16)}
+                    更新時間：{row.updated_at?.replace("T", " ").slice(0, 16)}
                   </p>
                   <p className="text-red-500">
-                    保存到期日：{row.updated_at.replace("T", " ").slice(0, 16)}
+                    保存到期日：{row.updated_at?.replace("T", " ").slice(0, 16)}
                   </p>
-                  <p className="text-red-500">
-                    回收會員：{row.user_id.slice(0, 16)}
-                  </p>
+                  <p className="text-red-500">回收會員：{row.user_id}</p>
                 </div>
               </div>
               <UpdateBoxForm row={row} />

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -108,7 +108,7 @@ export function useUpdateBox() {
     mutationFn: ({ boxId, values }) => apiUpdateBox(boxId, values),
     onSuccess: () => {
       toast.success("更新成功");
-      queryClient.invalidateQueries({ queryKey: ["boxes", "managing"] });
+      queryClient.invalidateQueries({ queryKey: ["boxes"] });
     },
     onError: (error) => {
       toast.error(error.message);

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -39,14 +39,14 @@ export function useBoxesForSelling() {
  *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
  *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
  */
-export function useBoxesForAdminManaging() {
+export function useBoxesForAdminManaging(stationId) {
   const {
     data: boxes,
     isLoading: isLoadingBoxes,
     error: boxesError,
   } = useQuery({
-    queryKey: ["boxes", "managing"],
-    queryFn: apiGetBoxesForAdminManaging,
+    queryKey: ["boxes", "managing", stationId],
+    queryFn: () => apiGetBoxesForAdminManaging(stationId),
   });
 
   return { boxes, isLoadingBoxes, boxesError };
@@ -62,14 +62,14 @@ export function useBoxesForAdminManaging() {
  *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
  *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
  */
-export function useBoxesForScraping() {
+export function useBoxesForScraping(stationId) {
   const {
     data: boxes,
     isLoading: isLoadingBoxes,
     error: boxesError,
   } = useQuery({
-    queryKey: ["boxes", "scrap"],
-    queryFn: apiGetBoxesForScraping,
+    queryKey: ["boxes", "scrap", stationId],
+    queryFn: () => apiGetBoxesForScraping(stationId),
   });
 
   return { boxes, isLoadingBoxes, boxesError };

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -2,6 +2,7 @@ import {
   apiGetBoxesForSelling,
   apiGetBoxesForAdminManaging,
   apiGetBoxesForScraping,
+  apiGetBoxesTotalForSelling,
 } from "@/services/apiBoxes";
 import toast from "react-hot-toast";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -69,6 +70,28 @@ export function useBoxesForScraping() {
   } = useQuery({
     queryKey: ["boxes", "scrap"],
     queryFn: apiGetBoxesForScraping,
+  });
+
+  return { boxes, isLoadingBoxes, boxesError };
+}
+/**
+ * 自訂 Hook：使用 React Query 來取得 5-2-3 待認領紙箱數量的紙箱資料
+ *
+ * 使用 `useQuery` 來向 API 請求 5-2-3 待認領紙箱數量的紙箱資料，並處理資料加載與錯誤狀態。
+ *
+ * @returns {Object} 返回包含三個屬性的物件：
+ *   - `boxes` {Array|null} - 紙箱資料陣列，若尚未請求或發生錯誤則為 `null`
+ *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
+ *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
+ */
+export function useBoxesTotalForSelling(stationId) {
+  const {
+    data: boxes,
+    isLoading: isLoadingBoxes,
+    error: boxesError,
+  } = useQuery({
+    queryKey: ["boxes", stationId],
+    queryFn: () => apiGetBoxesTotalForSelling(stationId),
   });
 
   return { boxes, isLoadingBoxes, boxesError };

--- a/src/pages/Member.jsx
+++ b/src/pages/Member.jsx
@@ -6,12 +6,12 @@ import MemberNav from "@/components/MemberNav";
 
 function Member() {
   return (
-    <div>
+    <>
       <Header />
       <MemberBanner />
       <MemberNav />
       <Footer />
-    </div>
+    </>
   );
 }
 

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -85,6 +85,35 @@ export async function apiGetBoxesForScraping() {
 }
 
 /**
+ * 從 Supabase 取得 5-2-3 待認領紙箱數量 的紙箱資料
+ *
+ * 該函式向 Supabase 的 `boxes` 表格請求 5-2-3 待認領紙箱數量的資料，並處理錯誤。
+ *
+ * @async
+ * @function apiGetBoxesForScraping
+ * @returns {Promise<Array>} 紙箱資料陣列，若請求成功返回資料，若失敗則會拋出錯誤
+ * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
+ */
+export async function apiGetBoxesTotalForSelling(stationId) {
+  try {
+    let { data: boxes, error } = await supabase
+      .from("boxes")
+      .select("size")
+      .in("status", ["可認領"])
+      .eq("station_id", stationId);
+
+    if (error) throw error;
+
+    return boxes;
+  } catch (error) {
+    // supabase 錯誤內容
+    console.error(error);
+    // UI 顯示的錯誤內容
+    throw new Error("無法取得 boxes 資料，請稍後再試");
+  }
+}
+
+/**
  * 從 Supabase 更新單一筆紙箱資料
  *
  * 該函式向 Supabase 的 `boxes` 表格更新單一筆的紙箱資料，並處理錯誤。

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -39,12 +39,13 @@ export async function apiGetBoxesForSelling() {
  * @returns {Promise<Array>} 紙箱資料陣列，若請求成功返回資料，若失敗則會拋出錯誤
  * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
  */
-export async function apiGetBoxesForAdminManaging() {
+export async function apiGetBoxesForAdminManaging(stationId) {
   try {
     let { data: boxes, error } = await supabase
       .from("boxes")
       .select("*")
-      .in("status", ["售出", "自用", "可認領"]);
+      .in("status", ["售出", "自用", "可認領"])
+      .eq("station_id", stationId);
 
     if (error) throw error;
 
@@ -67,12 +68,13 @@ export async function apiGetBoxesForAdminManaging() {
  * @returns {Promise<Array>} 紙箱資料陣列，若請求成功返回資料，若失敗則會拋出錯誤
  * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
  */
-export async function apiGetBoxesForScraping() {
+export async function apiGetBoxesForScraping(stationId) {
   try {
     let { data: boxes, error } = await supabase
       .from("boxes")
       .select("*")
-      .in("status", ["報廢", "保留到期"]);
+      .in("status", ["報廢", "保留到期"])
+      .eq("station_id", stationId);
 
     if (error) throw error;
 

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -1,4 +1,5 @@
 import supabase from "./supabase";
+import { getTimestamp } from "@/utils/helpers";
 
 /**
  * 從 Supabase 取得紙箱狀態為可認領的紙箱資料
@@ -128,7 +129,7 @@ export async function apiUpdateBox(boxId, values) {
   try {
     const { data: box, error } = await supabase
       .from("boxes")
-      .update({ ...values, updated_at: new Date() })
+      .update({ ...values, updated_at: getTimestamp() })
       .eq("id", boxId)
       .select();
     if (error) throw error;

--- a/src/services/apiStations.js
+++ b/src/services/apiStations.js
@@ -126,18 +126,12 @@ export async function updateStationHours(hoursData) {
   return { data, error };
 }
 
-export async function apiUpdateAvailableSlots({
-  stationId,
-  xlCounts,
-  lCounts,
-  mCounts,
-  sCounts,
-}) {
+export async function apiUpdateAvailableSlots({ stationId, S, M, L, XL }) {
   try {
     const { data, error } = await supabase
       .from("stations")
       .update({
-        available_slots: { L: lCounts, M: mCounts, S: sCounts, XL: xlCounts },
+        available_slots: { S, M, L, XL },
       })
       .eq("id", stationId)
       .select()


### PR DESCRIPTION
### **主要修改**
- 更新：4-1-1會員基本資訊、5-1-1 回收站點基本資訊
  - 根據 會員導覽列（會員頁面及管理者頁面）切換 4-1-1 及 5-1-1 內容 ( 尚未串接會員資料）
- 切版：新增 5-2 回收站點回收資訊總覽內容
  - 移除串接 站點讀取及更新 API 的測試內容
  - 更新 `components/AdminInfo.jsx` 元件：完成初步RWD切版
    - 新增：`components/form/AdminInfoForm.jsx`元件：5-2-1 編輯基本資訊表單元件
    - 新增：`components/form/AdminRecyclingBoxForm.jsx`元件：5-2-2 可回收空位數表單元件
    - 新增 `components/card/SellingBoxesCard.jsx`元件：5-2-3 待認領紙箱數量的小區塊共用樣式元件
    
- 串接：回收站管理者 - 編輯回收站點資訊
  - 新增 `useBoxesTotalForSelling(stationId)`: 讀取可認領紙箱數量API
  - 串接 `useStation`：讀取站點資訊：站點名稱、地址、電話、可回收紙箱的數量
  - 串接 `useUpdateAvailableSlots` 編輯紙箱可回收數量
  - 微調 `apiUpdateAvailableSlots` 更新的欄位名稱: `available_slots: { S, M, L, XL }`

備註：營業時間切版與串接更新資料API 下次更新

### **次要修改**
- 調整 `Header.jsx` div 標籤改為 header
- 調整 `MemberNav.jsx` html 標籤符合語意
- 更新：5-3 5-4 讀取紙箱API 綁定station_id

### **測試方式**
5-2-1
- [x] 更改 `useStation(stationId)` 傳遞的 stationId 是否可以正確讀取到 站點資料並顯示在輸入欄位內？

5-2-2
- [x] 編輯 5-2-2 可回收空位數 是否有正確更新到 `['station', id ]` queryKey 的 `available_slots`欄位?

5-2-3
- [x] 呼叫 `useBoxesTotalForSelling(stationId)` 是否修改傳遞的 stationId 取得紙箱狀態為 `["可認領"]` 紙箱資料？  
- [x] `useBoxesTotalForSelling(stationId)`返回的紙箱資料，經`totalBoxes()`函數計算是否可以正確渲染到5-2-3？

5-3 5-4
- [x] 切換 stationId，`useBoxesForScraping`和`useBoxesForAdminManaging`都可以取得對應的紙箱資料?

issue #31 
