### PR TITLE
Feature: 新增 4-3、4-4 取得會員紙箱交易紀錄API

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,12 +12,13 @@ import Signin from "./pages/Signin";
 import Signup from "./pages/Signup";
 import PageNotFound from "./pages/PageNotFound";
 import MemberInfo from "./components/MemberInfo";
-import PointRecords from "./components/PointRecords";
-import TransactionRecords from "./components/TransactionRecords";
+
 import AdminInfo from "./components/AdminInfo";
 import AdminBoxManageTable from "./components/table/AdminBoxManageTable";
 import AdminDeprecatedTable from "./components/table/AdminDeprecatedTable";
 import AdminTradeHistoryTable from "./components/table/AdminTradeHistoryTable";
+import MemberInfoHistoryTable from "./components/table/MemberInfoHistoryTable";
+import MemberInfoPointTable from "./components/table/MemberInfoPointTable";
 
 const queryClient = new QueryClient();
 
@@ -40,10 +41,10 @@ function App() {
             <Route path="normal">
               <Route index element={<Navigate replace to="memberInfo" />} />
               <Route path="memberInfo" element={<MemberInfo />} />
-              <Route path="pointsRecords" element={<PointRecords />} />
+              <Route path="pointsRecords" element={<MemberInfoPointTable />} />
               <Route
                 path="transactionRecords"
-                element={<TransactionRecords />}
+                element={<MemberInfoHistoryTable />}
               />
             </Route>
             <Route path="admin">

--- a/src/components/PointRecords.jsx
+++ b/src/components/PointRecords.jsx
@@ -1,5 +1,0 @@
-function PointRecords() {
-  return <div>4-3 一般會員 - 歷史積分紀錄列表</div>;
-}
-
-export default PointRecords;

--- a/src/components/TransactionRecords.jsx
+++ b/src/components/TransactionRecords.jsx
@@ -1,5 +1,0 @@
-function transactionRecords() {
-  return <div>4-4 一般會員 - 歷史回收記錄列表</div>;
-}
-
-export default transactionRecords;

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import DataTable from "react-data-table-component";
 import { StyleSheetManager } from "styled-components";
 import isPropValid from "@emotion/is-prop-valid";
+import { customStyles, paginationComponentOptions } from "@/data/constants";
 // react query
 import { useBoxesForAdminManaging } from "../..//hooks/useBoxes";
 import Spinner from "../../components/Spinner";
@@ -13,58 +14,6 @@ import { FaFolderPlus, FaCashRegister } from "react-icons/fa";
 // 更新紙箱、刪除紙箱資料表單元件
 import UpdateBoxDialog from "../dialog/UpdateBoxDialog";
 import DeleteBoxDialog from "../dialog/DeleteBoxDialog";
-
-// 表格內客製化樣式 (或建立style.css覆蓋樣式)
-const customStyles = {
-  table: {
-    style: {
-      border: "1px solid #d9d9d9",
-      boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
-    },
-  },
-  headRow: {
-    style: {
-      backgroundColor: "#F5F1E8",
-      borderBottomColor: "#d9d9d9",
-      fontWeight: "bold",
-      color: "#3d3d3d",
-    },
-  },
-  rows: {
-    style: {
-      "&:hover": {
-        backgroundColor: "#F3F3F3",
-      },
-    },
-  },
-  pagination: {
-    style: {
-      borderBottomLeftRadius: "8px",
-      borderBottomRightRadius: "8px",
-      backgroundColor: "#F5F1E8",
-      border: "1px solid #d9d9d9",
-      borderTop: "0px",
-    },
-  },
-  subHeader: {
-    style: {
-      border: "1px solid #d9d9d9",
-      borderBottom: "0px",
-      borderTopLeftRadius: "8px",
-      borderTopRightRadius: "8px",
-      backgroundColor: "#F5F1E8",
-      paddingTop: "24px",
-    },
-  },
-};
-
-// 客製化分頁元件
-const paginationComponentOptions = {
-  rowsPerPageText: "每頁顯示筆數",
-  rangeSeparatorText: "共",
-  selectAllRowsItem: true,
-  selectAllRowsItemText: "全部",
-};
 
 const AdminBoxManageTable = () => {
   // 篩選搜尋資料

--- a/src/components/table/AdminDeprecatedTable.jsx
+++ b/src/components/table/AdminDeprecatedTable.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import DataTable from "react-data-table-component";
 import { StyleSheetManager } from "styled-components";
 import isPropValid from "@emotion/is-prop-valid";
+import { customStyles, paginationComponentOptions } from "@/data/constants";
 // react query
 import { useBoxesForScraping } from "@/hooks/useBoxes";
 import Spinner from "@/components/Spinner";
@@ -12,58 +13,6 @@ import { FaTrashAlt } from "react-icons/fa";
 // 更新紙箱、刪除紙箱資料表單元件
 import UpdateBoxDialog from "../dialog/UpdateBoxDialog";
 import DeleteBoxDialog from "../dialog/DeleteBoxDialog";
-
-// 表格內客製化樣式 (或建立style.css覆蓋樣式)
-const customStyles = {
-  table: {
-    style: {
-      border: "1px solid #d9d9d9",
-      boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
-    },
-  },
-  headRow: {
-    style: {
-      backgroundColor: "#F5F1E8",
-      borderBottomColor: "#d9d9d9",
-      fontWeight: "bold",
-      color: "#3d3d3d",
-    },
-  },
-  rows: {
-    style: {
-      "&:hover": {
-        backgroundColor: "#F3F3F3",
-      },
-    },
-  },
-  pagination: {
-    style: {
-      borderBottomLeftRadius: "8px",
-      borderBottomRightRadius: "8px",
-      backgroundColor: "#F5F1E8",
-      border: "1px solid #d9d9d9",
-      borderTop: "0px",
-    },
-  },
-  subHeader: {
-    style: {
-      border: "1px solid #d9d9d9",
-      borderBottom: "0px",
-      borderTopLeftRadius: "8px",
-      borderTopRightRadius: "8px",
-      backgroundColor: "#F5F1E8",
-      paddingTop: "24px",
-    },
-  },
-};
-
-// 客製化分頁元件
-const paginationComponentOptions = {
-  rowsPerPageText: "每頁顯示筆數",
-  rangeSeparatorText: "共",
-  selectAllRowsItem: true,
-  selectAllRowsItemText: "全部",
-};
 
 const AdminDeprecatedTable = () => {
   // 篩選搜尋資料

--- a/src/components/table/AdminTradeHistoryTable.jsx
+++ b/src/components/table/AdminTradeHistoryTable.jsx
@@ -3,65 +3,16 @@
 import DataTable from "react-data-table-component";
 import { StyleSheetManager } from "styled-components";
 import isPropValid from "@emotion/is-prop-valid";
+import { customStyles, paginationComponentOptions } from "@/data/constants";
 // react query
-import { useTransactionRecords } from "@/hooks/useBoxTransactions";
+import { useAdminTransactionRecords } from "@/hooks/useBoxTransactions";
 import Spinner from "../../components/Spinner";
 import ErrorMessage from "../../components/ErrorMessage";
-// 表格內客製化樣式 (或建立style.css覆蓋樣式)
-const customStyles = {
-  table: {
-    style: {
-      border: "1px solid #d9d9d9",
-      boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
-    },
-  },
-  headRow: {
-    style: {
-      backgroundColor: "#F5F1E8",
-      borderBottomColor: "#d9d9d9",
-      fontWeight: "bold",
-      color: "#3d3d3d",
-    },
-  },
-  rows: {
-    style: {
-      "&:hover": {
-        backgroundColor: "#F3F3F3",
-      },
-    },
-  },
-  pagination: {
-    style: {
-      borderBottomLeftRadius: "8px",
-      borderBottomRightRadius: "8px",
-      backgroundColor: "#F5F1E8",
-      border: "1px solid #d9d9d9",
-      borderTop: "0px",
-    },
-  },
-  subHeader: {
-    style: {
-      border: "1px solid #d9d9d9",
-      borderBottom: "0px",
-      borderTopLeftRadius: "8px",
-      borderTopRightRadius: "8px",
-      backgroundColor: "#F5F1E8",
-      paddingTop: "24px",
-    },
-  },
-};
-
-// 客製化分頁元件
-const paginationComponentOptions = {
-  rowsPerPageText: "每頁顯示筆數",
-  rangeSeparatorText: "共",
-  selectAllRowsItem: true,
-  selectAllRowsItemText: "全部",
-};
 
 const AdminTradeHistoryTable = () => {
   // 取得可認領紙箱資料
-  const { records, isLoadingRecords, recordsError } = useTransactionRecords(16);
+  const { records, isLoadingRecords, recordsError } =
+    useAdminTransactionRecords(16);
   if (isLoadingRecords) return <Spinner />;
   if (recordsError) return <ErrorMessage errorMessage={recordsError.message} />;
   // 欄位

--- a/src/components/table/MemberInfoHistoryTable.jsx
+++ b/src/components/table/MemberInfoHistoryTable.jsx
@@ -1,5 +1,6 @@
 // 4-4 一般會員 - 歷史回收記錄列表
-import DataTable from 'react-data-table-component';
+import DataTable from "react-data-table-component";
+import { customStyles, paginationComponentOptions } from "@/data/constants";
 
 // 假資料
 const tempData = [
@@ -8,247 +9,210 @@ const tempData = [
     content: "回收 4 個紙箱",
     site: "台南圖書館",
     pointChange: "+50",
-    totalPoints: "1050"
+    totalPoints: "1050",
   },
   {
-    time: "2024-02-02 15:45", 
+    time: "2024-02-02 15:45",
     content: "購買 1 個紙箱",
     site: "米米小吃店",
     pointChange: "+10",
-    totalPoints: "1060"
+    totalPoints: "1060",
   },
   {
     time: "2024-02-03 09:15",
     content: "回收 1 個紙箱",
-    site: "葉子小舖", 
+    site: "葉子小舖",
     pointChange: "+100",
-    totalPoints: "1160"
+    totalPoints: "1160",
   },
   {
     time: "2024-02-04 14:20",
     content: "購買 1 個紙箱",
     site: "台南圖書館",
     pointChange: "-500",
-    totalPoints: "660"
+    totalPoints: "660",
   },
   {
     time: "2024-02-05 11:45",
     content: "回收 2 個紙箱",
     site: "米米小吃店",
     pointChange: "+200",
-    totalPoints: "860"
+    totalPoints: "860",
   },
   {
     time: "2024-02-01 10:30",
     content: "回收 4 個紙箱",
     site: "台南圖書館",
     pointChange: "+50",
-    totalPoints: "1050"
+    totalPoints: "1050",
   },
   {
-    time: "2024-02-02 15:45", 
+    time: "2024-02-02 15:45",
     content: "購買 1 個紙箱",
     site: "米米小吃店",
     pointChange: "+10",
-    totalPoints: "1060"
+    totalPoints: "1060",
   },
   {
     time: "2024-02-03 09:15",
     content: "回收 1 個紙箱",
-    site: "葉子小舖", 
+    site: "葉子小舖",
     pointChange: "+100",
-    totalPoints: "1160"
+    totalPoints: "1160",
   },
   {
     time: "2024-02-04 14:20",
     content: "購買 1 個紙箱",
     site: "台南圖書館",
     pointChange: "-500",
-    totalPoints: "660"
+    totalPoints: "660",
   },
   {
     time: "2024-02-05 11:45",
     content: "回收 2 個紙箱",
     site: "米米小吃店",
     pointChange: "+200",
-    totalPoints: "860"
+    totalPoints: "860",
   },
   {
     time: "2024-02-01 10:30",
     content: "回收 4 個紙箱",
     site: "台南圖書館",
     pointChange: "+50",
-    totalPoints: "1050"
+    totalPoints: "1050",
   },
   {
-    time: "2024-02-02 15:45", 
+    time: "2024-02-02 15:45",
     content: "購買 1 個紙箱",
     site: "米米小吃店",
     pointChange: "+10",
-    totalPoints: "1060"
+    totalPoints: "1060",
   },
   {
     time: "2024-02-03 09:15",
     content: "回收 1 個紙箱",
-    site: "葉子小舖", 
+    site: "葉子小舖",
     pointChange: "+100",
-    totalPoints: "1160"
+    totalPoints: "1160",
   },
   {
     time: "2024-02-04 14:20",
     content: "購買 1 個紙箱",
     site: "台南圖書館",
     pointChange: "-500",
-    totalPoints: "660"
+    totalPoints: "660",
   },
   {
     time: "2024-02-05 11:45",
     content: "回收 2 個紙箱",
     site: "米米小吃店",
     pointChange: "+200",
-    totalPoints: "860"
+    totalPoints: "860",
   },
   {
     time: "2024-02-01 10:30",
     content: "回收 4 個紙箱",
     site: "台南圖書館",
     pointChange: "+50",
-    totalPoints: "1050"
+    totalPoints: "1050",
   },
   {
-    time: "2024-02-02 15:45", 
+    time: "2024-02-02 15:45",
     content: "購買 1 個紙箱",
     site: "米米小吃店",
     pointChange: "+10",
-    totalPoints: "1060"
+    totalPoints: "1060",
   },
   {
     time: "2024-02-03 09:15",
     content: "回收 1 個紙箱",
-    site: "葉子小舖", 
+    site: "葉子小舖",
     pointChange: "+100",
-    totalPoints: "1160"
+    totalPoints: "1160",
   },
   {
     time: "2024-02-04 14:20",
     content: "購買 1 個紙箱",
     site: "台南圖書館",
     pointChange: "-500",
-    totalPoints: "660"
+    totalPoints: "660",
   },
   {
     time: "2024-02-05 11:45",
     content: "回收 2 個紙箱",
     site: "米米小吃店",
     pointChange: "+200",
-    totalPoints: "860"
+    totalPoints: "860",
   },
   {
     time: "2024-02-01 10:30",
     content: "回收 4 個紙箱",
     site: "台南圖書館",
     pointChange: "+50",
-    totalPoints: "1050"
+    totalPoints: "1050",
   },
   {
-    time: "2024-02-02 15:45", 
+    time: "2024-02-02 15:45",
     content: "購買 1 個紙箱",
     site: "米米小吃店",
     pointChange: "+10",
-    totalPoints: "1060"
+    totalPoints: "1060",
   },
   {
     time: "2024-02-03 09:15",
     content: "回收 1 個紙箱",
-    site: "葉子小舖", 
+    site: "葉子小舖",
     pointChange: "+100",
-    totalPoints: "1160"
+    totalPoints: "1160",
   },
   {
     time: "2024-02-04 14:20",
     content: "購買 1 個紙箱",
     site: "台南圖書館",
     pointChange: "-500",
-    totalPoints: "660"
+    totalPoints: "660",
   },
   {
     time: "2024-02-05 11:45",
     content: "回收 2 個紙箱",
     site: "米米小吃店",
     pointChange: "+200",
-    totalPoints: "860"
+    totalPoints: "860",
   },
-  
 ];
-
-// 表格內客製化樣式 (或建立style.css覆蓋樣式)
-const customStyles = {
-  table: {
-    style: {
-      borderRadius: '8px',
-      boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-    },
-  },
-  headRow: {
-    style: {
-      backgroundColor: '#f3f4f6',
-      borderBottomColor: '#e5e7eb',
-      fontWeight: 'bold',
-    },
-  },
-  rows: {
-    style: {
-      '&:hover': {
-        backgroundColor: '#f9fafb',
-      },
-    },
-  },
-  pagination: {
-    style: {
-      backgroundColor: '#f3f4f6',
-      borderTopColor: '#e5e7eb',
-    },
-  },
-};
-
-// 客製化分頁元件
-const paginationComponentOptions = {
-  rowsPerPageText: '每頁顯示筆數',
-  rangeSeparatorText: '共',
-  selectAllRowsItem: true,
-  selectAllRowsItemText: '全部',
-};
 
 const MemberInfoHistoryTable = () => {
   // 欄位
   const columns = [
     {
-      name: '交易時間',
-      selector: row => row.time,
+      name: "交易時間",
+      selector: (row) => row.time,
     },
     {
-      name: '交易形式',
-      selector: row => row.content,
+      name: "交易形式",
+      selector: (row) => row.content,
     },
     {
-      name: '交易站點',
-      selector: row => row.site,
+      name: "交易站點",
+      selector: (row) => row.site,
     },
     {
-      name: '紙箱大小',
-      selector: row => row.site,
+      name: "紙箱大小",
+      selector: (row) => row.site,
     },
     {
-      name: '紙箱保存等級',
-      selector: row => row.site,
+      name: "紙箱保存等級",
+      selector: (row) => row.site,
     },
     {
-      name: '換算積分',
-      selector: row => row.pointChange,
-      cell: row => (
-        <span style={{ 
-          color: row.pointChange.startsWith('+') ? 'green' : 'red' 
-        }}>
+      name: "換算積分",
+      selector: (row) => row.pointChange,
+      cell: (row) => (
+        <span
+          style={{
+            color: row.pointChange.startsWith("+") ? "green" : "red",
+          }}
+        >
           {row.pointChange}
         </span>
       ),
@@ -260,7 +224,6 @@ const MemberInfoHistoryTable = () => {
       columns={columns}
       data={tempData}
       pagination
-      title="紙箱交易紀錄"
       customStyles={customStyles}
       paginationComponentOptions={paginationComponentOptions}
     />

--- a/src/components/table/MemberInfoPointTable.jsx
+++ b/src/components/table/MemberInfoPointTable.jsx
@@ -1,5 +1,6 @@
 // 4-3 一般會員-歷史積分紀錄列表
-import DataTable from 'react-data-table-component';
+import DataTable from "react-data-table-component";
+import { customStyles, paginationComponentOptions } from "@/data/constants";
 
 // 假資料
 const tempData = [
@@ -8,246 +9,209 @@ const tempData = [
     content: "回收 4 個紙箱",
     site: "台南圖書館",
     pointChange: "+50",
-    totalPoints: "1050"
+    totalPoints: "1050",
   },
   {
-    time: "2024-02-02 15:45", 
+    time: "2024-02-02 15:45",
     content: "購買 1 個紙箱",
     site: "米米小吃店",
     pointChange: "+10",
-    totalPoints: "1060"
+    totalPoints: "1060",
   },
   {
     time: "2024-02-03 09:15",
     content: "回收 1 個紙箱",
-    site: "葉子小舖", 
+    site: "葉子小舖",
     pointChange: "+100",
-    totalPoints: "1160"
+    totalPoints: "1160",
   },
   {
     time: "2024-02-04 14:20",
     content: "購買 1 個紙箱",
     site: "台南圖書館",
     pointChange: "-500",
-    totalPoints: "660"
+    totalPoints: "660",
   },
   {
     time: "2024-02-05 11:45",
     content: "回收 2 個紙箱",
     site: "米米小吃店",
     pointChange: "+200",
-    totalPoints: "860"
+    totalPoints: "860",
   },
   {
     time: "2024-02-01 10:30",
     content: "回收 4 個紙箱",
     site: "台南圖書館",
     pointChange: "+50",
-    totalPoints: "1050"
+    totalPoints: "1050",
   },
   {
-    time: "2024-02-02 15:45", 
+    time: "2024-02-02 15:45",
     content: "購買 1 個紙箱",
     site: "米米小吃店",
     pointChange: "+10",
-    totalPoints: "1060"
+    totalPoints: "1060",
   },
   {
     time: "2024-02-03 09:15",
     content: "回收 1 個紙箱",
-    site: "葉子小舖", 
+    site: "葉子小舖",
     pointChange: "+100",
-    totalPoints: "1160"
+    totalPoints: "1160",
   },
   {
     time: "2024-02-04 14:20",
     content: "購買 1 個紙箱",
     site: "台南圖書館",
     pointChange: "-500",
-    totalPoints: "660"
+    totalPoints: "660",
   },
   {
     time: "2024-02-05 11:45",
     content: "回收 2 個紙箱",
     site: "米米小吃店",
     pointChange: "+200",
-    totalPoints: "860"
+    totalPoints: "860",
   },
   {
     time: "2024-02-01 10:30",
     content: "回收 4 個紙箱",
     site: "台南圖書館",
     pointChange: "+50",
-    totalPoints: "1050"
+    totalPoints: "1050",
   },
   {
-    time: "2024-02-02 15:45", 
+    time: "2024-02-02 15:45",
     content: "購買 1 個紙箱",
     site: "米米小吃店",
     pointChange: "+10",
-    totalPoints: "1060"
+    totalPoints: "1060",
   },
   {
     time: "2024-02-03 09:15",
     content: "回收 1 個紙箱",
-    site: "葉子小舖", 
+    site: "葉子小舖",
     pointChange: "+100",
-    totalPoints: "1160"
+    totalPoints: "1160",
   },
   {
     time: "2024-02-04 14:20",
     content: "購買 1 個紙箱",
     site: "台南圖書館",
     pointChange: "-500",
-    totalPoints: "660"
+    totalPoints: "660",
   },
   {
     time: "2024-02-05 11:45",
     content: "回收 2 個紙箱",
     site: "米米小吃店",
     pointChange: "+200",
-    totalPoints: "860"
+    totalPoints: "860",
   },
   {
     time: "2024-02-01 10:30",
     content: "回收 4 個紙箱",
     site: "台南圖書館",
     pointChange: "+50",
-    totalPoints: "1050"
+    totalPoints: "1050",
   },
   {
-    time: "2024-02-02 15:45", 
+    time: "2024-02-02 15:45",
     content: "購買 1 個紙箱",
     site: "米米小吃店",
     pointChange: "+10",
-    totalPoints: "1060"
+    totalPoints: "1060",
   },
   {
     time: "2024-02-03 09:15",
     content: "回收 1 個紙箱",
-    site: "葉子小舖", 
+    site: "葉子小舖",
     pointChange: "+100",
-    totalPoints: "1160"
+    totalPoints: "1160",
   },
   {
     time: "2024-02-04 14:20",
     content: "購買 1 個紙箱",
     site: "台南圖書館",
     pointChange: "-500",
-    totalPoints: "660"
+    totalPoints: "660",
   },
   {
     time: "2024-02-05 11:45",
     content: "回收 2 個紙箱",
     site: "米米小吃店",
     pointChange: "+200",
-    totalPoints: "860"
+    totalPoints: "860",
   },
   {
     time: "2024-02-01 10:30",
     content: "回收 4 個紙箱",
     site: "台南圖書館",
     pointChange: "+50",
-    totalPoints: "1050"
+    totalPoints: "1050",
   },
   {
-    time: "2024-02-02 15:45", 
+    time: "2024-02-02 15:45",
     content: "購買 1 個紙箱",
     site: "米米小吃店",
     pointChange: "+10",
-    totalPoints: "1060"
+    totalPoints: "1060",
   },
   {
     time: "2024-02-03 09:15",
     content: "回收 1 個紙箱",
-    site: "葉子小舖", 
+    site: "葉子小舖",
     pointChange: "+100",
-    totalPoints: "1160"
+    totalPoints: "1160",
   },
   {
     time: "2024-02-04 14:20",
     content: "購買 1 個紙箱",
     site: "台南圖書館",
     pointChange: "-500",
-    totalPoints: "660"
+    totalPoints: "660",
   },
   {
     time: "2024-02-05 11:45",
     content: "回收 2 個紙箱",
     site: "米米小吃店",
     pointChange: "+200",
-    totalPoints: "860"
+    totalPoints: "860",
   },
-  
 ];
-
-// 表格內客製化樣式 (或建立style.css覆蓋樣式)
-const customStyles = {
-  table: {
-    style: {
-      borderRadius: '8px',
-      boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-    },
-  },
-  headRow: {
-    style: {
-      backgroundColor: '#f3f4f6',
-      borderBottomColor: '#e5e7eb',
-      fontWeight: 'bold',
-    },
-  },
-  rows: {
-    style: {
-      '&:hover': {
-        backgroundColor: '#f9fafb',
-      },
-    },
-  },
-  pagination: {
-    style: {
-      backgroundColor: '#f3f4f6',
-      borderTopColor: '#e5e7eb',
-    },
-  },
-};
-
-// 客製化分頁元件
-const paginationComponentOptions = {
-  rowsPerPageText: '每頁顯示筆數',
-  rangeSeparatorText: '共',
-  selectAllRowsItem: true,
-  selectAllRowsItemText: '全部',
-};
 
 const MemberInfoPointTable = () => {
   // 欄位
   const columns = [
     {
-      name: '交易時間',
-      selector: row => row.time,
+      name: "交易時間",
+      selector: (row) => row.time,
     },
     {
-      name: '交易內容',
-      selector: row => row.content,
+      name: "交易內容",
+      selector: (row) => row.content,
     },
     {
-      name: '交易站點',
-      selector: row => row.site,
+      name: "交易站點",
+      selector: (row) => row.site,
     },
     {
-      name: '積分變化',
-      selector: row => row.pointChange,
-      cell: row => (
-        <span style={{ 
-          color: row.pointChange.startsWith('+') ? 'green' : 'red' 
-        }}>
+      name: "積分變化",
+      selector: (row) => row.pointChange,
+      cell: (row) => (
+        <span
+          style={{
+            color: row.pointChange.startsWith("+") ? "green" : "red",
+          }}
+        >
           {row.pointChange}
         </span>
       ),
     },
     {
-      name: '積分總計',
-      selector: row => row.totalPoints,
+      name: "積分總計",
+      selector: (row) => row.totalPoints,
     },
   ];
 
@@ -256,7 +220,6 @@ const MemberInfoPointTable = () => {
       columns={columns}
       data={tempData}
       pagination
-      title="積分紀錄"
       customStyles={customStyles}
       paginationComponentOptions={paginationComponentOptions}
     />

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,0 +1,51 @@
+// Table 客製化樣式
+export const customStyles = {
+  table: {
+    style: {
+      border: "1px solid #d9d9d9",
+      boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+    },
+  },
+  headRow: {
+    style: {
+      backgroundColor: "#F5F1E8",
+      borderBottomColor: "#d9d9d9",
+      fontWeight: "bold",
+      color: "#3d3d3d",
+    },
+  },
+  rows: {
+    style: {
+      "&:hover": {
+        backgroundColor: "#F3F3F3",
+      },
+    },
+  },
+  pagination: {
+    style: {
+      borderBottomLeftRadius: "8px",
+      borderBottomRightRadius: "8px",
+      backgroundColor: "#F5F1E8",
+      border: "1px solid #d9d9d9",
+      borderTop: "0px",
+    },
+  },
+  subHeader: {
+    style: {
+      border: "1px solid #d9d9d9",
+      borderBottom: "0px",
+      borderTopLeftRadius: "8px",
+      borderTopRightRadius: "8px",
+      backgroundColor: "#F5F1E8",
+      paddingTop: "24px",
+    },
+  },
+};
+
+// Table 客製化分頁元件
+export const paginationComponentOptions = {
+  rowsPerPageText: "每頁顯示筆數",
+  rangeSeparatorText: "共",
+  selectAllRowsItem: true,
+  selectAllRowsItemText: "全部",
+};

--- a/src/hooks/useBoxTransactions.js
+++ b/src/hooks/useBoxTransactions.js
@@ -1,24 +1,50 @@
-import { apiGetTransactionRecords } from "@/services/apiBoxTransactions";
+import {
+  apiGetAdminTransactionRecords,
+  apiGetMemberTransactionRecords,
+} from "@/services/apiBoxTransactions";
 import { useQuery } from "@tanstack/react-query";
 
 /**
- * 自訂 Hook：使用 React Query 來取得 5-5 紙箱交易紀錄的交易資料
+ * 自訂 Hook：使用 React Query 來取得 管理者-紙箱交易紀錄的交易資料
  *
- * 使用 `useQuery` 來向 API 請求 5-5 紙箱交易紀錄的交易資料，並處理資料加載與錯誤狀態。
+ * 使用 `useQuery` 來向 API 請求 管理者-紙箱交易紀錄的交易資料，並處理資料加載與錯誤狀態。
  *
  * @returns {Object} 返回包含三個屬性的物件：
  *   - `boxes` {Array|null} - 紙箱資料陣列，若尚未請求或發生錯誤則為 `null`
  *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
  *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
  */
-export function useTransactionRecords(stationId) {
+export function useAdminTransactionRecords(stationId) {
   const {
     data: records,
     isLoading: isLoadingRecords,
     error: recordsError,
   } = useQuery({
     queryKey: ["boxes-transactions", stationId],
-    queryFn: () => apiGetTransactionRecords(stationId),
+    queryFn: () => apiGetAdminTransactionRecords(stationId),
+  });
+
+  return { records, isLoadingRecords, recordsError };
+}
+
+/**
+ * 自訂 Hook：使用 React Query 來取得 一般會員-紙箱交易紀錄的交易資料
+ *
+ * 使用 `useQuery` 來向 API 請求 一般會員-紙箱交易紀錄的交易資料，並處理資料加載與錯誤狀態。
+ *
+ * @returns {Object} 返回包含三個屬性的物件：
+ *   - `boxes` {Array|null} - 紙箱資料陣列，若尚未請求或發生錯誤則為 `null`
+ *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
+ *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
+ */
+export function useMemberTransactionRecords(userId) {
+  const {
+    data: records,
+    isLoading: isLoadingRecords,
+    error: recordsError,
+  } = useQuery({
+    queryKey: ["boxes-transactions", userId],
+    queryFn: () => apiGetMemberTransactionRecords(userId),
   });
 
   return { records, isLoadingRecords, recordsError };

--- a/src/services/apiBoxTransactions.js
+++ b/src/services/apiBoxTransactions.js
@@ -1,21 +1,49 @@
 import supabase from "./supabase";
 
 /**
- * 從 Supabase 取得 5-5 紙箱交易紀錄的交易資料
+ * 從 Supabase 取得 管理者-紙箱交易紀錄的交易資料
  *
- * 該函式向 Supabase 的 `boxes` 表格請求 5-5 紙箱交易紀錄的交易資料，並處理錯誤。
+ * 該函式向 Supabase 的 `boxes` 表格請求 管理者-紙箱交易紀錄的交易資料，並處理錯誤。
  *
  * @async
- * @function apiGetTransactionRecords
+ * @function apiGetAdminTransactionRecords
  * @returns {Promise<Array>} 紙箱資料陣列，若請求成功返回資料，若失敗則會拋出錯誤
  * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
  */
-export async function apiGetTransactionRecords(stationId) {
+export async function apiGetAdminTransactionRecords(stationId) {
   try {
     let { data: records, error } = await supabase
       .from("box-transactions")
       .select("*")
       .eq("station_id", stationId);
+
+    if (error) throw error;
+
+    return records;
+  } catch (error) {
+    // supabase 錯誤內容
+    console.error("讀取 box-transactions 發生錯誤:", error);
+    // UI 顯示的錯誤內容
+    throw new Error("無法取得 box-transactions 資料，請稍後再試");
+  }
+}
+
+/**
+ * 從 Supabase 取得 一般會員-紙箱交易紀錄的交易資料
+ *
+ * 該函式向 Supabase 的 `boxes` 表格請求 一般會員-紙箱交易紀錄的交易資料，並處理錯誤。
+ *
+ * @async
+ * @function apiGetMemberTransactionRecords
+ * @returns {Promise<Array>} 紙箱資料陣列，若請求成功返回資料，若失敗則會拋出錯誤
+ * @throws {Error} 如果請求過程中發生錯誤，則會拋出錯誤
+ */
+export async function apiGetMemberTransactionRecords(userId) {
+  try {
+    let { data: records, error } = await supabase
+      .from("box-transactions")
+      .select("*")
+      .eq("user_id", userId);
 
     if (error) throw error;
 


### PR DESCRIPTION
### 主要修改
- 新增 一般會員－讀取紙箱交易紀錄API
  - 4-3、4-4 共用 API：`hooks/useBoxTransactions/useMemberTransactionRecords`
 
- 更新 `App.js` 中 4-3、4-4 路由
  - `/member/normal/pointsRecords`：指向 `MemberInfoPointTable.jsx` 元件
  - `/member/normal/transactionRecords`：指向 `MemberInfoHistoryTable.jsx` 元件

### 次要修改
- 刪除`PointRecords.jsx`及`TransactionRecords.jsx`多餘元件
- Table 客製化樣式`customStyles`及 Table 分頁元件 `paginationComponentOptions` 單獨拆到 `data/constants.js` 簡化重複程式碼
- 重命名讀取紙箱交易紀錄API
  - 會員：useMemberTransactionRecords
  - 管理者：useAdminTransactionRecords

### 測試方式
- [x] 呼叫 useMemberTransactionRecords是否可以依據useId讀取交易紀錄
