### PR TITLE
Feature: 更新 5-2-1 編輯基本資訊

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/is-prop-valid": "^1.3.1",
         "@hookform/resolvers": "^4.0.0",
+        "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.5",
         "@radix-ui/react-label": "^2.1.2",
@@ -1207,6 +1208,59 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.1.4.tgz",
+      "integrity": "sha512-wP0CPAHq+P5I4INKe3hJrIa1WoNqqrejzW+zoU0rOvo1b9gDEJJFl2rYfO1PYJUQCc2H1WZxIJmyv9BS8i5fLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@emotion/is-prop-valid": "^1.3.1",
     "@hookform/resolvers": "^4.0.0",
+    "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.5",
     "@radix-ui/react-label": "^2.1.2",

--- a/src/components/form/AdminInfoForm.jsx
+++ b/src/components/form/AdminInfoForm.jsx
@@ -4,80 +4,66 @@ import toast from "react-hot-toast";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
 import { FaPen, FaTimes } from "react-icons/fa";
-import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
+// import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
 
 const formSchema = z.object({
   station_name: z.string().nonempty("站點名稱不得為空"),
   address: z.string().nonempty("地址不得為空"),
   phone: z.string().nonempty("電話不得為空"),
+  station_daily_hours: z.array(
+    z.object({
+      id: z.number(),
+      open_time: z.string().optional(),
+      close_time: z.string().optional(),
+      is_business_day: z.boolean(),
+    }),
+  ),
 });
+import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
 
 import PropTypes from "prop-types";
 AdminInfoForm.propTypes = { station: PropTypes.object };
+
+const daysOfWeek = [
+  "星期日",
+  "星期一",
+  "星期二",
+  "星期三",
+  "星期四",
+  "星期五",
+  "星期六",
+];
 
 function AdminInfoForm({ station }) {
   const [isEditing, setIsEditing] = useState(false);
   const { updateStation, isUpdating } = useUpdateStationInfo();
 
-  const form = useForm({
+  const { handleSubmit, register } = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
       station_name: station.station_name || "",
       address: station.address || "",
       phone: station.phone || "",
+      station_daily_hours: Array.from({ length: 7 }, (_, index) => {
+        const dayData = station.station_daily_hours.find(
+          (item) => item.day_of_week === index,
+        );
+
+        return {
+          id: dayData ? dayData.id : "",
+          open_time: dayData ? dayData.open_time.substring(0, 5) : "",
+          close_time: dayData ? dayData.close_time.substring(0, 5) : "",
+          is_business_day: dayData ? dayData.is_business_day : false,
+        };
+      }),
     },
   });
-
-  // 更新站點資訊格式：
-  // {
-  //   id: 1,   // station id
-  //   station_name: "多米葉漢堡",
-  //   address: "新北市樹林區佳園路2段104號",
-  //   phone: "+886-2-26802008",
-  //   station_daily_hours: [
-  //     {
-  //       id: 70,
-  //       open_time: "08:00:00+00",
-  //       close_time: "20:00:00+00",
-  //       day_of_week: 6,
-  //       is_business_day: true,
-  //     },
-  //   ],
-  // }
 
   function onSubmit(values) {
     try {
       console.log(values);
-      updateStation({
-        ...values,
-        id: station.id,
-        station_daily_hours: [
-          {
-            id: 69,
-            open_time: "08:00:00+00",
-            close_time: "20:00:00+00",
-            day_of_week: 5,
-            is_business_day: true,
-          },
-          {
-            id: 70,
-            open_time: "08:00:00+00",
-            close_time: "20:00:00+00",
-            day_of_week: 6,
-            is_business_day: true,
-          },
-        ],
-      });
+      updateStation({ ...values, id: station.id });
     } catch (error) {
       toast.error("Form submission error", error);
     }
@@ -95,86 +81,82 @@ function AdminInfoForm({ station }) {
           )}
         </button>
       </div>
-      <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit(onSubmit)}
-          className="mx-auto max-w-3xl space-y-4 py-6"
-        >
-          <FormField
-            control={form.control}
-            name="station_name"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  <h6 className="text-gray-700">站點名稱</h6>
-                </FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="請輸入站點名稱"
-                    value={station.station_name}
-                    type="text"
-                    {...field}
-                    disabled={!isEditing}
-                  />
-                </FormControl>
 
-                <FormMessage />
-              </FormItem>
-            )}
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="mx-auto max-w-3xl space-y-4 py-6"
+      >
+        <div className="flex items-center">
+          <label className="w-1/5">
+            <h6 className="text-main-600">站點名稱</h6>
+          </label>
+          <input
+            {...register("station_name")}
+            placeholder="輸入店名"
+            className="w-3/5 rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
+            disabled={!isEditing}
           />
+        </div>
 
-          <FormField
-            control={form.control}
-            name="address"
-            render={({ field }) => (
-              <FormItem className="mt-6">
-                <FormLabel>
-                  <h6 className="text-gray-700">地址</h6>
-                </FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="請輸入站點地址"
-                    value={station.address}
-                    type="text"
-                    {...field}
-                    disabled={!isEditing}
-                  />
-                </FormControl>
-
-                <FormMessage />
-              </FormItem>
-            )}
+        <div className="flex items-center">
+          <label className="w-1/5">
+            <h6 className="text-main-600">地址</h6>
+          </label>
+          <input
+            {...register("address")}
+            placeholder="輸入地址"
+            className="w-3/5 rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
+            disabled={!isEditing}
           />
+        </div>
 
-          <FormField
-            control={form.control}
-            name="phone"
-            render={({ field }) => (
-              <FormItem className="mt-6">
-                <FormLabel>
-                  <h6 className="text-gray-700">電話</h6>
-                </FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="請輸入電話號碼"
-                    value={station.phone}
-                    type="text"
-                    {...field}
-                    disabled={!isEditing}
-                  />
-                </FormControl>
-
-                <FormMessage />
-              </FormItem>
-            )}
+        <div className="flex items-center">
+          <label className="w-1/5">
+            <h6 className="text-main-600">電話</h6>
+          </label>
+          <input
+            {...register("phone")}
+            placeholder="輸入電話"
+            className="w-3/5 rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
+            disabled={!isEditing}
           />
-          {isEditing && (
-            <button className="btn" type="submit" disabled={isUpdating}>
-              {isUpdating ? "更新中" : "確認修改"}
-            </button>
-          )}
-        </form>
-      </Form>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label className="mb-2">
+            <h6 className="text-main-600">營業時間</h6>
+          </label>
+          {daysOfWeek.map((day, index) => (
+            <div key={index} className="flex items-center space-x-4">
+              <input
+                type="checkbox"
+                {...register(`station_daily_hours.${index}.is_business_day`)}
+                disabled={!isEditing}
+              />
+              <span>{day}</span>
+              <input
+                {...register(`station_daily_hours.${index}.open_time`)}
+                placeholder="開店時間"
+                type="time"
+                disabled={!isEditing}
+                className="w-1/3 rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
+              />
+              <input
+                {...register(`station_daily_hours.${index}.close_time`)}
+                placeholder="關店時間"
+                type="time"
+                disabled={!isEditing}
+                className="w-1/3 rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
+              />
+            </div>
+          ))}
+        </div>
+        {isEditing && (
+          <button className="btn" type="submit" disabled={isUpdating}>
+            {isUpdating ? "更新中" : "確認修改"}
+          </button>
+        )}
+      </form>
     </>
   );
 }

--- a/src/components/form/UpdateBoxForm.jsx
+++ b/src/components/form/UpdateBoxForm.jsx
@@ -119,7 +119,9 @@ export default function UpdateBoxForm({ row, setOpen }) {
               <FormLabel>紙箱保留天數</FormLabel>
               <Select
                 onValueChange={(value) => field.onChange(Number(value))}
-                defaultValue={row.retention_days?.toString()}
+                defaultValue={
+                  row.retention_days ? row.retention_days.toString() : "0"
+                }
               >
                 <FormControl>
                   <SelectTrigger>
@@ -127,6 +129,9 @@ export default function UpdateBoxForm({ row, setOpen }) {
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
+                  <SelectItem value="0" disabled>
+                    0
+                  </SelectItem>
                   <SelectItem value="7">7</SelectItem>
                   <SelectItem value="30">30</SelectItem>
                   <SelectItem value="60">60</SelectItem>

--- a/src/components/ui/checkbox.jsx
+++ b/src/components/ui/checkbox.jsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}>
+    <CheckboxPrimitive.Indicator className={cn("flex items-center justify-center text-current")}>
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/src/index.css
+++ b/src/index.css
@@ -182,3 +182,14 @@
     @apply bg-background text-foreground;
   }
 }
+
+
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}


### PR DESCRIPTION
### 主要更改
- 切版：更新 5-2-1 編輯基本資訊
- 串接：讀取、更新營業時間

### 次要修改
- 更新 `UpdateBoxForm.jsx`：保留天數預設值如果為空，顯示為0

### 測試方法
- [x] 測試讀取站點基本資訊：在`admin/adminInfo.jsx` 元件 更新 `useStation(stationId)`，AdminInfoForm 表單中管理者基本資訊是否會一併更新？
- [x] 點擊編輯按鈕後，是否所有欄位都可以編輯？
- [x] 送出 AdminInfoForm 表單，是否能夠更新資訊，並提示更新成功？

issue #31 