### PR TITLE
feat: 完成 4-1 讀取會員資訊、更新會員資訊

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,11 +30,11 @@ function App() {
       <HashRouter>
         <Routes>
           <Route path="/" element={<HomePage />} />
-          <Route path="map" element={<MapPage />}>
+          <Route path="/map" element={<MapPage />}>
             <Route index element={<Map />} />
             <Route path=":stationId" element={<StationInfo />} />
           </Route>
-          <Route path="member" element={<Member />}>
+          <Route path="/member" element={<Member />}>
             <Route
               index
               element={<Navigate replace to="normal/memberInfo" />}
@@ -59,8 +59,8 @@ function App() {
               />
             </Route>
           </Route>
-          <Route path="signin" element={<Signin />} />
-          <Route path="signup" element={<Signup />} />
+          <Route path="/signin" element={<Signin />} />
+          <Route path="/signup" element={<Signup />} />
           <Route path="*" element={<PageNotFound />} />
 
           {/* 測試用 */}

--- a/src/components/MemberInfo.jsx
+++ b/src/components/MemberInfo.jsx
@@ -5,6 +5,8 @@ import box_count from "../assets/box_count.svg";
 import ResponsiveSwiper from "./ui/ResponsiveSwiper";
 import MemberInfoForm from "./form/MemberInfoForm";
 
+import { useMember } from "@/hooks/useMember";
+
 const style = {
   cardContainer: "flex items-center justify-around rounded-2xl bg-white p-10",
   cardText: "text-2xl font-bold",
@@ -12,6 +14,9 @@ const style = {
 };
 
 function MemberInfo() {
+  const { member, isLoadingMember, getMemberError } = useMember();
+  console.log(member);
+
   return (
     <div className="w-full text-center">
       <div className="my-20">

--- a/src/components/form/MemberInfoForm.jsx
+++ b/src/components/form/MemberInfoForm.jsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 
 // Icon
 import { FaPen } from "react-icons/fa";
+import { useUpdateMember } from "@/hooks/useUpdateMember";
 
 // zod驗證規則
 const formSchema = z.object({
@@ -40,11 +41,26 @@ function MemberInfoForm() {
   const { reset, formState } = form;
   const { isSubmitSuccessful } = formState;
 
-  // 串接API後繼續完成
-  // const onSubmit = (data) => {
-  //   console.log(data);
-  //   setIsEditing(false);
+  const { updateMember, updateMemberError, isUpdating } = useUpdateMember();
+
+  // update 物件格式：
+  // const obj = {
+  //   data: {
+  //     avatar_url: "https://fakeimg.pl/200/",
+  //     display_name: "王志豪",
+  //     phone: "+886956135395",
+  //     points: 48,
+  //     roles: ["users", "storeOwner"],
+  //     transaction_nums: 121,
+  //   },
   // };
+
+  // 串接API後繼續完成
+  const onSubmit = (data) => {
+    console.log(data);
+    // setIsEditing(false);
+  };
+
   return (
     <div className="order-2 rounded-3xl bg-white p-10 md:order-1 md:w-1/2">
       <div className="mb-6 flex items-center justify-between">
@@ -57,7 +73,7 @@ function MemberInfoForm() {
       </div>
 
       <Form {...form}>
-        <form onSubmit={form.handleSubmit()} noValidate>
+        <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
           <FormField
             control={form.control}
             name="name"

--- a/src/hooks/useMember.js
+++ b/src/hooks/useMember.js
@@ -1,0 +1,15 @@
+import { apiGetMember } from "@/services/apiAuth";
+import { useQuery } from "@tanstack/react-query";
+
+export function useMember() {
+  const {
+    data: member,
+    isLoading: isLoadingMember,
+    error: getMemberError,
+  } = useQuery({
+    queryKey: ["member"],
+    queryFn: () => apiGetMember(),
+  });
+
+  return { member, isLoadingMember, getMemberError };
+}

--- a/src/hooks/useSignIn.js
+++ b/src/hooks/useSignIn.js
@@ -23,7 +23,7 @@ export function useSignIn() {
       // 3. UI 提示訊息
       toast.success(`登入成功`);
 
-      // 4. 跳轉回資訊頁
+      // 4. 跳轉回首頁
       navigate("/", { replace: true });
     },
     onError: (error) => {

--- a/src/hooks/useUpdateMember.js
+++ b/src/hooks/useUpdateMember.js
@@ -1,0 +1,28 @@
+import { apiUpdateMember } from "@/services/apiAuth";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+
+export function useUpdateMember() {
+  const queryClient = useQueryClient();
+
+  const {
+    mutate: updateMember,
+    error: updateMemberError,
+    isPending: isUpdating,
+  } = useMutation({
+    mutationKey: ["updateMember"],
+    mutationFn: apiUpdateMember,
+    onError: (error) => {
+      console.error(error.message);
+      toast.error(`更新資料失敗`);
+    },
+    onSuccess: () => {
+      toast.success("更新成功");
+      queryClient.invalidateQueries({
+        queryKey: ["member"],
+      });
+    },
+  });
+
+  return { updateMember, updateMemberError, isUpdating };
+}

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -49,3 +49,19 @@ export async function apiSignOut() {
     throw new Error(error.message);
   }
 }
+
+export async function apiGetMember() {
+  try {
+    const signInUser = { email: "test01@gmail.com", password: "password1" };
+
+    await apiSignIn(signInUser);
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    return user;
+  } catch (error) {
+    throw new Error(error.message);
+  }
+}

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -52,6 +52,7 @@ export async function apiSignOut() {
 
 export async function apiGetMember() {
   try {
+    // 測試使用，先登入後取得資料。
     const signInUser = { email: "test01@gmail.com", password: "password1" };
 
     await apiSignIn(signInUser);
@@ -61,6 +62,29 @@ export async function apiGetMember() {
     } = await supabase.auth.getUser();
 
     return user;
+  } catch (error) {
+    throw new Error(error.message);
+  }
+}
+
+// update 物件格式：
+// const obj = {
+//   data: {
+//     avatar_url: "https://fakeimg.pl/200/",
+//     display_name: "王志豪",
+//     phone: "+886956135395",
+//     points: 48,
+//     roles: ["users", "storeOwner"],
+//     transaction_nums: 121,
+//   },
+// };
+export async function apiUpdateMember(newInfoObj) {
+  try {
+    const { data, error } = await supabase.auth.updateUser(newInfoObj);
+
+    if (error) throw error;
+
+    return data;
   } catch (error) {
     throw new Error(error.message);
   }


### PR DESCRIPTION
### 主要變更

1. `apiAuth` 

    - 新增 `apiGetMember` 方法，處理 讀取已登入會員資訊  supabase  api 請求
    - 新增 `apiUpdateMember` 方法，處理 更新已登入會員資訊  supabase  api 請求

2. 新增 `useMember` 自定義 hook，使用 react query 管理 API 請求觸發、資料緩存。
3.  新增 `useUpdateMember` 自定義 hook，使用 react query 管理 API 請求觸發、資料緩存、成功與失敗的提示。

---
### 次要變更

1. `App.jsx`：調整 HashRouter 下的 Route path 為絕對路徑，讓路徑解析為 `/#/map`、 `/#/member`

---
### 測試方法

- [ ] 執行 useMember 是否能取得登入使用者資料？
- [ ] 執行 useUpdateMember 回傳的 updateMember mutate 方法是否能更新使用者資料，並自動刷新資訊？ 
