### PR TITLE
Feat: 新增5-7交易紙箱頁面、表單驗證、整合送出資料

### DIFF
--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -1,4 +1,3 @@
-// 5-7 回收站點管理者後台 - 售出紙箱流程
 import AdminTradeTable from "./table/AdminTradeTable";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -7,29 +6,70 @@ import memberBannerBg01 from "@/assets/memberBanner-bg1.svg";
 import Header from "./Header";
 import Footer from "./Footer";
 import { useState } from "react";
+import { Controller, FormProvider, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { useNavigate } from "react-router-dom";
+
+// 驗證 schema
+const formSchema = z.object({
+  userId: z.string().min(1, { message: "會員編號為必填" }),
+  selectedRows: z.array(z.any()).min(1, { message: "尚未選擇要交易的項目" }),
+});
 
 function AdminTrade() {
+  const navigate = useNavigate();
+
+  // 使用 useForm 並確保 methods 正確傳遞
+  const methods = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      userId: "",
+      selectedRows: [],
+    },
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+  } = methods;
+
   // 選取計算
-  const [selectedRows, setSelectedRows] = useState([]);
   const [totalCash, setTotalCash] = useState(0);
   const [totalPoints, setTotalPoints] = useState(0);
   const [selectedCounts, setSelectedCounts] = useState(0);
+
+  // 取得時間
+  const [currentTime, setCurrentTime] = useState(new Date().toLocaleString());
+
+  // 當用戶選擇紙箱時，更新表單狀態
   const handleSelectChange = ({ selectedRows }) => {
-    setSelectedRows(selectedRows);
+    setValue("selectedRows", selectedRows); // 更新表單中的 selectedRows
 
-    const cashSum = selectedRows.reduce((sum, item) => {
-      return sum + item.cash_value;
-    }, 0);
-
-    const pointSum = selectedRows.reduce((sum, item) => {
-      return sum + item.point_value;
-    }, 0);
-
+    const cashSum = selectedRows.reduce(
+      (sum, item) => sum + item.cash_value,
+      0,
+    );
+    const pointSum = selectedRows.reduce(
+      (sum, item) => sum + item.point_value,
+      0,
+    );
     const counts = selectedRows.length;
 
     setTotalCash(cashSum);
     setTotalPoints(pointSum);
     setSelectedCounts(counts);
+  };
+
+  const onSubmit = (data) => {
+    const formData = {
+      ...data,
+      currentTime: new Date().toLocaleString(), // 送出時取得最新時間
+    };
+    console.log("提交的資料:", formData);
+    navigate("/member/admin/boxesTable"); // 轉向至 5-3
   };
 
   return (
@@ -49,67 +89,90 @@ function AdminTrade() {
       </section>
       <div className="mb-[500px]"></div>
 
-      <div className="z-100 container absolute left-0 right-0 top-16 mx-auto my-5 flex flex-col items-center justify-center">
-        <div className="mb-3 flex w-1/3 justify-center">
-          <p className="my-5 w-full border-b-4 border-b-main-600 pb-5 text-center text-4xl font-bold text-main-600">
-            交易紙箱
-          </p>
-        </div>
-        <div className="w-full rounded-xl bg-[#fafafa] p-5">
-          <div className="w-1/3">
-            <div className="mb-5 flex flex-1 items-center">
-              <Label className="w-1/3 text-2xl font-bold text-main-600">
-                交易時間
-              </Label>
-              <Label className="w-full text-2xl text-main-600">
-                {new Date().toLocaleString()}
-              </Label>
-            </div>
-            <div className="mb-5 flex flex-1 items-center">
-              <Label className="w-1/3 text-2xl font-bold text-main-600">
-                會員編號
-              </Label>
-              <Input className="w-full" type="text"></Input>
-            </div>
-          </div>
-          <AdminTradeTable handleSelectChange={handleSelectChange} />
-          <div className="flex w-full justify-end gap-5">
-            <div className="flex-1"></div>
-            <div className="flex-1"></div>
-            <div className="flex flex-1 justify-center">
-              <p className="p-5">
-                現金總計：<span>{totalCash}</span>
-              </p>
-              <p className="p-5">
-                積分總計：<span>{totalPoints}</span>
+      {/* 確保 FormProvider 正確包裹住表單 */}
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div className="z-100 container absolute left-0 right-0 top-16 mx-auto my-5 flex flex-col items-center justify-center">
+            <div className="mb-3 flex w-1/3 justify-center">
+              <p className="my-5 w-full border-b-4 border-b-main-600 pb-5 text-center text-4xl font-bold text-main-600">
+                交易紙箱
               </p>
             </div>
-          </div>
-          <div className="my-5 flex items-center justify-between">
-            <div className="flex flex-1 flex-col items-start">
-              <div className="mb-3 flex w-1/2">
-                <p className="w-1/3 text-xl font-bold">交易紙箱數</p>
-                <p className="text-xl">{selectedCounts} 個紙箱</p>
+            <div className="w-full rounded-xl bg-[#fafafa] p-5">
+              <div className="w-1/2">
+                <div className="mb-5 flex flex-1 items-center">
+                  <Label className="mr-5 text-2xl font-bold text-main-600">
+                    交易時間
+                  </Label>
+                  <Label className="text-2xl text-main-600">
+                    {currentTime}
+                  </Label>
+                </div>
+                <div className="mb-5 flex flex-1 items-center">
+                  <Label className="mr-5 text-2xl font-bold text-main-600">
+                    會員編號
+                  </Label>
+                  <Input className="w-72" type="text" {...register("userId")} />
+                  {errors.userId && (
+                    <p className="ml-5 text-red-500">{errors.userId.message}</p>
+                  )}
+                </div>
               </div>
-              <div className="flex w-1/2 items-center">
-                <p className="w-1/3 text-xl font-bold">支付方式</p>
-                <select className="text-xl" name="" id="">
-                  <option value="cash">現金</option>
-                  <option value="creditCard">信用卡</option>
-                </select>
+
+              {/* 確保 AdminTradeTable 被包裹在 FormProvider 內 */}
+              <AdminTradeTable handleSelectChange={handleSelectChange} />
+
+              {/* 顯示錯誤訊息 */}
+              {errors.selectedRows && (
+                <p className="text-red-500">{errors.selectedRows.message}</p>
+              )}
+
+              <div className="flex w-full gap-5">
+                <div className="mr-10 flex flex-1 justify-end">
+                  <p className="p-5">
+                    現金總計：<span>{totalCash}</span>
+                  </p>
+                  <p className="p-5">
+                    積分總計：<span>{totalPoints}</span>
+                  </p>
+                </div>
+              </div>
+
+              <div className="my-5 flex items-center justify-between">
+                <div className="flex flex-1 flex-col items-start">
+                  <div className="mb-3 flex w-1/2">
+                    <p className="w-1/3 text-xl font-bold">交易紙箱數</p>
+                    <p className="text-xl">{selectedCounts} 個紙箱</p>
+                  </div>
+                  <div className="flex w-1/2 items-center">
+                    <p className="w-1/3 text-xl font-bold">支付方式</p>
+                    <Controller
+                      name="paymentMethod"
+                      control={methods.control}
+                      defaultValue="cash"
+                      render={({ field }) => (
+                        <select className="text-xl" {...field}>
+                          <option value="cash">現金</option>
+                          <option value="creditCard">信用卡</option>
+                        </select>
+                      )}
+                    />
+                  </div>
+                </div>
+
+                <div className="flex flex-1 gap-3">
+                  <button className="btn w-1/2 text-xl" type="submit">
+                    確認送出
+                  </button>
+                  <button className="btn w-1/2 text-xl" type="button">
+                    取消
+                  </button>
+                </div>
               </div>
             </div>
-            <div className="flex flex-1 gap-3">
-              <button className="btn w-1/2 text-xl" type="button">
-                確認送出
-              </button>
-              <button className="btn w-1/2 text-xl" type="button">
-                取消
-              </button>
-            </div>
           </div>
-        </div>
-      </div>
+        </form>
+      </FormProvider>
       <Footer />
     </>
   );

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -149,11 +149,11 @@ function AdminTrade() {
                     <Controller
                       name="paymentMethod"
                       control={methods.control}
-                      defaultValue="cash"
+                      defaultValue="選擇支付方式"
                       render={({ field }) => (
                         <select className="text-xl" {...field}>
                           <option value="cash">現金</option>
-                          <option value="creditCard">信用卡</option>
+                          <option value="points">積分</option>
                         </select>
                       )}
                     />

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -15,6 +15,7 @@ import { useNavigate } from "react-router-dom";
 const formSchema = z.object({
   userId: z.string().min(1, { message: "會員編號為必填" }),
   selectedRows: z.array(z.any()).min(1, { message: "尚未選擇要交易的項目" }),
+  paymentMethod: z.enum(["cash", "points"]),
 });
 
 function AdminTrade() {
@@ -26,6 +27,7 @@ function AdminTrade() {
     defaultValues: {
       userId: "",
       selectedRows: [],
+      paymentMethod: "cash",
     },
   });
 
@@ -40,9 +42,6 @@ function AdminTrade() {
   const [totalCash, setTotalCash] = useState(0);
   const [totalPoints, setTotalPoints] = useState(0);
   const [selectedCounts, setSelectedCounts] = useState(0);
-
-  // 取得時間
-  const [currentTime, setCurrentTime] = useState(new Date().toLocaleString());
 
   // 當用戶選擇紙箱時，更新表單狀態
   const handleSelectChange = ({ selectedRows }) => {
@@ -64,11 +63,7 @@ function AdminTrade() {
   };
 
   const onSubmit = (data) => {
-    const formData = {
-      ...data,
-      currentTime: new Date().toLocaleString(), // 送出時取得最新時間
-    };
-    console.log("提交的資料:", formData);
+    console.log("提交的資料:", data);
     navigate("/member/admin/boxesTable"); // 轉向至 5-3
   };
 
@@ -105,7 +100,7 @@ function AdminTrade() {
                     交易時間
                   </Label>
                   <Label className="text-2xl text-main-600">
-                    {currentTime}
+                    {new Date().toLocaleString()}
                   </Label>
                 </div>
                 <div className="mb-5 flex flex-1 items-center">
@@ -149,7 +144,7 @@ function AdminTrade() {
                     <Controller
                       name="paymentMethod"
                       control={methods.control}
-                      defaultValue="選擇支付方式"
+                      defaultValue="cash"
                       render={({ field }) => (
                         <select className="text-xl" {...field}>
                           <option value="cash">現金</option>

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -6,8 +6,32 @@ import { Label } from "@/components/ui/label";
 import memberBannerBg01 from "@/assets/memberBanner-bg1.svg";
 import Header from "./Header";
 import Footer from "./Footer";
+import { useState } from "react";
 
 function AdminTrade() {
+  // 選取計算
+  const [selectedRows, setSelectedRows] = useState([]);
+  const [totalCash, setTotalCash] = useState(0);
+  const [totalPoints, setTotalPoints] = useState(0);
+  const [selectedCounts, setSelectedCounts] = useState(0);
+  const handleSelectChange = ({ selectedRows }) => {
+    setSelectedRows(selectedRows);
+
+    const cashSum = selectedRows.reduce((sum, item) => {
+      return sum + item.cash_value;
+    }, 0);
+
+    const pointSum = selectedRows.reduce((sum, item) => {
+      return sum + item.point_value;
+    }, 0);
+
+    const counts = selectedRows.length;
+
+    setTotalCash(cashSum);
+    setTotalPoints(pointSum);
+    setSelectedCounts(counts);
+  };
+
   return (
     <>
       <Header />
@@ -48,16 +72,16 @@ function AdminTrade() {
               <Input className="w-full" type="text"></Input>
             </div>
           </div>
-          <AdminTradeTable />
+          <AdminTradeTable handleSelectChange={handleSelectChange} />
           <div className="flex w-full justify-end gap-5">
             <div className="flex-1"></div>
             <div className="flex-1"></div>
             <div className="flex flex-1 justify-center">
               <p className="p-5">
-                現金總計：<span>17</span>
+                現金總計：<span>{totalCash}</span>
               </p>
               <p className="p-5">
-                積分總計：<span>14</span>
+                積分總計：<span>{totalPoints}</span>
               </p>
             </div>
           </div>
@@ -65,7 +89,7 @@ function AdminTrade() {
             <div className="flex flex-1 flex-col items-start">
               <div className="mb-3 flex w-1/2">
                 <p className="w-1/3 text-xl font-bold">交易紙箱數</p>
-                <p className="text-xl">{"3"} 個紙箱</p>
+                <p className="text-xl">{selectedCounts} 個紙箱</p>
               </div>
               <div className="flex w-1/2 items-center">
                 <p className="w-1/3 text-xl font-bold">支付方式</p>

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -6,10 +6,8 @@ import { Label } from "@/components/ui/label";
 import memberBannerBg01 from "@/assets/memberBanner-bg1.svg";
 import Header from "./Header";
 import Footer from "./Footer";
-import { useState } from "react";
 
 function AdminTrade() {
-  const [filterText, setFilterText] = useState("");
   return (
     <>
       <Header />
@@ -49,16 +47,6 @@ function AdminTrade() {
               </Label>
               <Input className="w-full" type="text"></Input>
             </div>
-          </div>
-          {/* 搜尋框 */}
-          <div className="mb-3 flex w-full justify-start">
-            <input
-              type="text"
-              placeholder="搜尋紙箱編號"
-              value={filterText}
-              onChange={(e) => setFilterText(e.target.value)}
-              className="rounded border p-2"
-            />
           </div>
           <AdminTradeTable />
           <div className="flex w-full justify-end gap-5">

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -21,7 +21,6 @@ const formSchema = z.object({
 function AdminTrade() {
   const navigate = useNavigate();
 
-  // 使用 useForm 並確保 methods 正確傳遞
   const methods = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -43,7 +42,6 @@ function AdminTrade() {
   const [totalPoints, setTotalPoints] = useState(0);
   const [selectedCounts, setSelectedCounts] = useState(0);
 
-  // 當用戶選擇紙箱時，更新表單狀態
   const handleSelectChange = ({ selectedRows }) => {
     setValue("selectedRows", selectedRows); // 更新表單中的 selectedRows
 
@@ -84,7 +82,6 @@ function AdminTrade() {
       </section>
       <div className="mb-[500px]"></div>
 
-      {/* 確保 FormProvider 正確包裹住表單 */}
       <FormProvider {...methods}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="z-100 container absolute left-0 right-0 top-16 mx-auto my-5 flex flex-col items-center justify-center">
@@ -114,7 +111,6 @@ function AdminTrade() {
                 </div>
               </div>
 
-              {/* 確保 AdminTradeTable 被包裹在 FormProvider 內 */}
               <AdminTradeTable handleSelectChange={handleSelectChange} />
 
               {/* 顯示錯誤訊息 */}

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -1,25 +1,105 @@
 // 5-7 回收站點管理者後台 - 售出紙箱流程
-
 import AdminTradeTable from "./table/AdminTradeTable";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import memberBannerBg01 from "@/assets/memberBanner-bg1.svg";
+import Header from "./Header";
+import Footer from "./Footer";
+import { useState } from "react";
 
 function AdminTrade() {
+  const [filterText, setFilterText] = useState("");
   return (
-    <div className="container flex flex-col items-center">
-      <div>
-        <p>交易紙箱</p>
-      </div>
-      <div>
-        <div className="flex">
-          <p className="mr-3">交易時間</p>
-          <p>2024/11/28 15:32</p>
+    <>
+      <Header />
+      <section className="bg-[#F3F3F3] bg-top bg-no-repeat md:bg-[url('@/assets/memberBanner-bg2.svg')]">
+        <div className="container relative mx-auto flex flex-col items-center gap-10 py-20 text-center md:flex-row md:justify-between md:text-left">
+          <div className="relative h-[201px] w-[200px]">
+            <img
+              src={memberBannerBg01}
+              alt="背景圖"
+              className="absolute -bottom-3 -left-14 hidden md:flex"
+            />
+          </div>
+          <div className="relative h-60 w-80 md:w-[500px]"></div>
         </div>
-        <div className="flex">
-          <p className="mr-3">會員編號</p>
-          <input className="border" type="number" />
+      </section>
+      <div className="mb-[500px]"></div>
+
+      <div className="z-100 container absolute left-0 right-0 top-16 mx-auto my-5 flex flex-col items-center justify-center">
+        <div className="mb-3 flex w-1/3 justify-center">
+          <p className="my-5 w-full border-b-4 border-b-main-600 pb-5 text-center text-4xl font-bold text-main-600">
+            交易紙箱
+          </p>
         </div>
-        <AdminTradeTable />
+        <div className="w-full rounded-xl bg-[#fafafa] p-5">
+          <div className="w-1/3">
+            <div className="mb-5 flex flex-1 items-center">
+              <Label className="w-1/3 text-2xl font-bold text-main-600">
+                交易時間
+              </Label>
+              <Label className="w-full text-2xl text-main-600">
+                {new Date().toLocaleString()}
+              </Label>
+            </div>
+            <div className="mb-5 flex flex-1 items-center">
+              <Label className="w-1/3 text-2xl font-bold text-main-600">
+                會員編號
+              </Label>
+              <Input className="w-full" type="text"></Input>
+            </div>
+          </div>
+          {/* 搜尋框 */}
+          <div className="mb-3 flex w-full justify-start">
+            <input
+              type="text"
+              placeholder="搜尋紙箱編號"
+              value={filterText}
+              onChange={(e) => setFilterText(e.target.value)}
+              className="rounded border p-2"
+            />
+          </div>
+          <AdminTradeTable />
+          <div className="flex w-full justify-end gap-5">
+            <div className="flex-1"></div>
+            <div className="flex-1"></div>
+            <div className="flex flex-1 justify-center">
+              <p className="p-5">
+                現金總計：<span>17</span>
+              </p>
+              <p className="p-5">
+                積分總計：<span>14</span>
+              </p>
+            </div>
+          </div>
+          <div className="my-5 flex items-center justify-between">
+            <div className="flex flex-1 flex-col items-start">
+              <div className="mb-3 flex w-1/2">
+                <p className="w-1/3 text-xl font-bold">交易紙箱數</p>
+                <p className="text-xl">{"3"} 個紙箱</p>
+              </div>
+              <div className="flex w-1/2 items-center">
+                <p className="w-1/3 text-xl font-bold">支付方式</p>
+                <select className="text-xl" name="" id="">
+                  <option value="cash">現金</option>
+                  <option value="creditCard">信用卡</option>
+                </select>
+              </div>
+            </div>
+            <div className="flex flex-1 gap-3">
+              <button className="btn w-1/2 text-xl" type="button">
+                確認送出
+              </button>
+              <button className="btn w-1/2 text-xl" type="button">
+                取消
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
+      <Footer />
+    </>
   );
 }
 

--- a/src/components/table/AdminTradeTable.jsx
+++ b/src/components/table/AdminTradeTable.jsx
@@ -1,5 +1,5 @@
 // 5-7 回收站點管理者後台 - 售出紙箱流程
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import DataTable from "react-data-table-component";
 import { StyleSheetManager } from "styled-components";
 import isPropValid from "@emotion/is-prop-valid";
@@ -48,7 +48,27 @@ const customStyles = {
 const AdminTradeTable = () => {
   // 資料
   const { boxes, isLoadingBoxes, boxesError } = useBoxesForSelling(16);
-  const data = boxes;
+
+  // 篩選搜尋資料
+  const [originData, setOriginData] = useState([]);
+  const [filterText, setFilterText] = useState("");
+  const [filteredData, setFilteredData] = useState([]);
+
+  useEffect(() => {
+    if (boxes?.length || 0 > 0) {
+      // 若boxes回傳為undefined則無法計算length會報錯，加?避免錯誤
+      setOriginData(boxes);
+      setFilteredData(boxes);
+    }
+  }, [boxes]);
+
+  useEffect(() => {
+    const filtered = originData.filter((item) =>
+      item.id.toString().includes(filterText),
+    );
+    setFilteredData(filtered);
+  }, [filterText, originData]);
+  // 搜尋欄、原始資料變動時觸發
 
   // 欄位
   const columns = [
@@ -99,17 +119,24 @@ const AdminTradeTable = () => {
     },
   ];
 
-  // 篩選搜尋資料
-  // const [filterText, setFilterText] = useState("");
-
   if (isLoadingBoxes) return <Spinner />;
   if (boxesError) return <ErrorMessage errorMessage={boxesError.message} />;
 
   return (
     <StyleSheetManager shouldForwardProp={isPropValid}>
+      {/* 搜尋框 */}
+      <div className="mb-3 flex w-full justify-start">
+        <input
+          type="text"
+          placeholder="搜尋紙箱編號"
+          value={filterText}
+          onChange={(e) => setFilterText(e.target.value)}
+          className="rounded border p-2"
+        />
+      </div>
       <DataTable
         columns={columns}
-        data={data}
+        data={filteredData}
         customStyles={customStyles}
         selectableRows
         fixedHeader

--- a/src/components/table/AdminTradeTable.jsx
+++ b/src/components/table/AdminTradeTable.jsx
@@ -45,10 +45,9 @@ const customStyles = {
   },
 };
 
-const AdminTradeTable = () => {
+const AdminTradeTable = ({ handleSelectChange }) => {
   // 資料
   const { boxes, isLoadingBoxes, boxesError } = useBoxesForSelling(16);
-
   // 篩選搜尋資料
   const [originData, setOriginData] = useState([]);
   const [filterText, setFilterText] = useState("");
@@ -139,6 +138,7 @@ const AdminTradeTable = () => {
         data={filteredData}
         customStyles={customStyles}
         selectableRows
+        onSelectedRowsChange={handleSelectChange}
         fixedHeader
         fixedHeaderScrollHeight="350px"
       />

--- a/src/components/table/AdminTradeTable.jsx
+++ b/src/components/table/AdminTradeTable.jsx
@@ -3,299 +3,117 @@ import { useState } from "react";
 import DataTable from "react-data-table-component";
 import { StyleSheetManager } from "styled-components";
 import isPropValid from "@emotion/is-prop-valid";
-
-// 假資料
-const tempData = [
-  {
-    time: "2024-02-01 10:30",
-    content: "回收 4 個紙箱",
-    site: "台南圖書館",
-    pointChange: "+50",
-    totalPoints: "1050",
-  },
-  {
-    time: "2024-02-02 15:45",
-    content: "購買 1 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+10",
-    totalPoints: "1060",
-  },
-  {
-    time: "2024-02-03 09:15",
-    content: "回收 1 個紙箱",
-    site: "葉子小舖",
-    pointChange: "+100",
-    totalPoints: "1160",
-  },
-  {
-    time: "2024-02-04 14:20",
-    content: "購買 1 個紙箱",
-    site: "台南圖書館",
-    pointChange: "-500",
-    totalPoints: "660",
-  },
-  {
-    time: "2024-02-05 11:45",
-    content: "回收 2 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+200",
-    totalPoints: "860",
-  },
-  {
-    time: "2024-02-01 10:30",
-    content: "回收 4 個紙箱",
-    site: "台南圖書館",
-    pointChange: "+50",
-    totalPoints: "1050",
-  },
-  {
-    time: "2024-02-02 15:45",
-    content: "購買 1 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+10",
-    totalPoints: "1060",
-  },
-  {
-    time: "2024-02-03 09:15",
-    content: "回收 1 個紙箱",
-    site: "葉子小舖",
-    pointChange: "+100",
-    totalPoints: "1160",
-  },
-  {
-    time: "2024-02-04 14:20",
-    content: "購買 1 個紙箱",
-    site: "台南圖書館",
-    pointChange: "-500",
-    totalPoints: "660",
-  },
-  {
-    time: "2024-02-05 11:45",
-    content: "回收 2 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+200",
-    totalPoints: "860",
-  },
-  {
-    time: "2024-02-01 10:30",
-    content: "回收 4 個紙箱",
-    site: "台南圖書館",
-    pointChange: "+50",
-    totalPoints: "1050",
-  },
-  {
-    time: "2024-02-02 15:45",
-    content: "購買 1 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+10",
-    totalPoints: "1060",
-  },
-  {
-    time: "2024-02-03 09:15",
-    content: "回收 1 個紙箱",
-    site: "葉子小舖",
-    pointChange: "+100",
-    totalPoints: "1160",
-  },
-  {
-    time: "2024-02-04 14:20",
-    content: "購買 1 個紙箱",
-    site: "台南圖書館",
-    pointChange: "-500",
-    totalPoints: "660",
-  },
-  {
-    time: "2024-02-05 11:45",
-    content: "回收 2 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+200",
-    totalPoints: "860",
-  },
-  {
-    time: "2024-02-01 10:30",
-    content: "回收 4 個紙箱",
-    site: "台南圖書館",
-    pointChange: "+50",
-    totalPoints: "1050",
-  },
-  {
-    time: "2024-02-02 15:45",
-    content: "購買 1 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+10",
-    totalPoints: "1060",
-  },
-  {
-    time: "2024-02-03 09:15",
-    content: "回收 1 個紙箱",
-    site: "葉子小舖",
-    pointChange: "+100",
-    totalPoints: "1160",
-  },
-  {
-    time: "2024-02-04 14:20",
-    content: "購買 1 個紙箱",
-    site: "台南圖書館",
-    pointChange: "-500",
-    totalPoints: "660",
-  },
-  {
-    time: "2024-02-05 11:45",
-    content: "回收 2 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+200",
-    totalPoints: "860",
-  },
-  {
-    time: "2024-02-01 10:30",
-    content: "回收 4 個紙箱",
-    site: "台南圖書館",
-    pointChange: "+50",
-    totalPoints: "1050",
-  },
-  {
-    time: "2024-02-02 15:45",
-    content: "購買 1 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+10",
-    totalPoints: "1060",
-  },
-  {
-    time: "2024-02-03 09:15",
-    content: "回收 1 個紙箱",
-    site: "葉子小舖",
-    pointChange: "+100",
-    totalPoints: "1160",
-  },
-  {
-    time: "2024-02-04 14:20",
-    content: "購買 1 個紙箱",
-    site: "台南圖書館",
-    pointChange: "-500",
-    totalPoints: "660",
-  },
-  {
-    time: "2024-02-05 11:45",
-    content: "回收 2 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+200",
-    totalPoints: "860",
-  },
-];
+import { useBoxesForSelling } from "@/hooks/useBoxes";
+import Spinner from "../Spinner";
+import ErrorMessage from "../ErrorMessage";
 
 // 表格內客製化樣式 (或建立style.css覆蓋樣式)
 const customStyles = {
   table: {
     style: {
-      borderRadius: "8px",
+      border: "1px solid #d9d9d9",
       boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
     },
   },
   headRow: {
     style: {
-      backgroundColor: "#f3f4f6",
-      borderBottomColor: "#e5e7eb",
+      backgroundColor: "#F5F1E8",
+      borderBottomColor: "#d9d9d9",
       fontWeight: "bold",
+      color: "#3d3d3d",
+      position: "sticky",
+      left: 0,
+      zIndex: 2, // 確保它不會被其他內容蓋住
     },
   },
   rows: {
     style: {
       "&:hover": {
-        backgroundColor: "#f9fafb",
+        backgroundColor: "#F3F3F3",
       },
-    },
-  },
-  pagination: {
-    style: {
-      backgroundColor: "#f3f4f6",
-      borderTopColor: "#e5e7eb",
     },
   },
   subHeader: {
     style: {
-      padding: "0px",
+      border: "1px solid #d9d9d9",
+      borderBottom: "0px",
+      borderTopLeftRadius: "8px",
+      borderTopRightRadius: "8px",
+      backgroundColor: "#F5F1E8",
+      paddingTop: "24px",
     },
   },
 };
 
 const AdminTradeTable = () => {
+  // 資料
+  const { boxes, isLoadingBoxes, boxesError } = useBoxesForSelling(16);
+  const data = boxes;
+
   // 欄位
   const columns = [
     {
       name: "新增時間",
-      selector: (row) => row.time,
+      selector: (row) => row.updated_at?.replace("T", " ").slice(0, 16),
       sortable: true,
     },
     {
       name: "紙箱編號",
-      selector: (row) => row.content,
+      selector: (row) => row.id,
       sortable: true,
     },
     {
       name: "紙箱大小",
-      selector: (row) => row.site,
+      selector: (row) => row.size,
       sortable: true,
     },
     {
       name: "紙箱保存等級",
-      selector: (row) => row.totalPoints,
+      selector: (row) => row.condition,
       sortable: true,
     },
     {
       name: "保留天數",
-      selector: (row) => row.totalPoints,
+      selector: (row) => row.retention_days,
       sortable: true,
     },
     {
       name: "保留到期日",
-      selector: (row) => row.totalPoints,
+      selector: (row) => row.size,
       sortable: true,
     },
     {
       name: "狀態",
-      selector: (row) => row.totalPoints,
+      selector: (row) => row.status,
       sortable: true,
     },
     {
       name: "現金",
-      selector: (row) => row.totalPoints,
+      selector: (row) => row.cash_value,
       sortable: true,
     },
     {
       name: "積分",
-      selector: (row) => row.totalPoints,
+      selector: (row) => row.point_value,
       sortable: true,
     },
   ];
 
   // 篩選搜尋資料
-  const [filterText, setFilterText] = useState("");
+  // const [filterText, setFilterText] = useState("");
 
-  // const filteredData = pointsData.filter(
-  //   item => Object.values(item).some(
-  //     val => val.toString().toLowerCase().includes(filterText.toLowerCase())
-  //   )
-  // );
+  if (isLoadingBoxes) return <Spinner />;
+  if (boxesError) return <ErrorMessage errorMessage={boxesError.message} />;
 
   return (
     <StyleSheetManager shouldForwardProp={isPropValid}>
       <DataTable
         columns={columns}
-        data={tempData}
+        data={data}
         customStyles={customStyles}
         selectableRows
-        subHeader
-        subHeaderComponent={
-          <div className="flex w-full justify-start">
-            <input
-              type="text"
-              placeholder="搜尋紙箱編號"
-              value={filterText}
-              onChange={(e) => setFilterText(e.target.value)}
-              className="rounded border p-2"
-            />
-          </div>
-        }
+        fixedHeader
+        fixedHeaderScrollHeight="350px"
       />
     </StyleSheetManager>
   );


### PR DESCRIPTION
### **任務項目**
- 新增5-7交易紙箱頁面
- 畫面切版
- 讀取API
- 表單驗證

- 提交資訊：
1. 會員編號：userId
2. 表格資料：selectedRows
3. 支付方式：paymentMethod

### **測試**
 驗證：
- 會員編號必填
- 至少勾選1個紙箱

Submit：
- 送出後console.log內容包含：userId、selectedRows、paymentMethod
- 送出後跳轉至5-3

### **待完成項目**
串接編輯紙箱紀錄API

開發負責人：@JohnnyHsiehTW