### PR TITLE
Feature: 更新 5-6 回收站點管理者後台 - 新增紙箱流程

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,6 +54,7 @@ function App() {
               <Route path="adminInfo" element={<AdminInfo />} />
               <Route path="boxesTable" element={<AdminBoxManageTable />} />
               <Route path="addBoxes" element={<AdminAddBoxes />} />
+              <Route path="tradeBoxes" element={<AdminTrade />} />
               <Route path="recyclingTable" element={<AdminDeprecatedTable />} />
               <Route
                 path="adminTransactionRecords"

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -2,14 +2,14 @@ import AdminTradeTable from "./table/AdminTradeTable";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-import memberBannerBg01 from "@/assets/memberBanner-bg1.svg";
-import Header from "./Header";
-import Footer from "./Footer";
+// import memberBannerBg01 from "@/assets/memberBanner-bg1.svg";
+// import Header from "./Header";
+// import Footer from "./Footer";
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 // 驗證 schema
 const formSchema = z.object({
@@ -20,7 +20,10 @@ const formSchema = z.object({
 
 function AdminTrade() {
   const navigate = useNavigate();
-
+  // 從 5-3 傳遞 station_id
+  const location = useLocation();
+  const { station_id } = location.state;
+  console.log("5-7收到站點編號", station_id);
   const methods = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -67,7 +70,7 @@ function AdminTrade() {
 
   return (
     <>
-      <Header />
+      {/* <Header />
       <section className="bg-[#F3F3F3] bg-top bg-no-repeat md:bg-[url('@/assets/memberBanner-bg2.svg')]">
         <div className="container relative mx-auto flex flex-col items-center gap-10 py-20 text-center md:flex-row md:justify-between md:text-left">
           <div className="relative h-[201px] w-[200px]">
@@ -79,12 +82,12 @@ function AdminTrade() {
           </div>
           <div className="relative h-60 w-80 md:w-[500px]"></div>
         </div>
-      </section>
-      <div className="mb-[500px]"></div>
+      </section> 
+      <div className="mb-[500px]"></div>*/}
 
       <FormProvider {...methods}>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <div className="z-100 container absolute left-0 right-0 top-16 mx-auto my-5 flex flex-col items-center justify-center">
+          <div className="z-100 container top-16 mx-auto my-5 flex flex-col items-center justify-center">
             <div className="mb-3 flex w-1/3 justify-center">
               <p className="my-5 w-full border-b-4 border-b-main-600 pb-5 text-center text-4xl font-bold text-main-600">
                 交易紙箱
@@ -164,7 +167,7 @@ function AdminTrade() {
           </div>
         </form>
       </FormProvider>
-      <Footer />
+      {/* <Footer /> */}
     </>
   );
 }

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -112,7 +112,6 @@ const AdminBoxManageTable = () => {
                 <button
                   className="btn flex items-center gap-1 border p-2"
                   onClick={() => {
-                    console.log(boxes.at(0).station_id);
                     navigate("/member/admin/addBoxes", {
                       state: { station_id: boxes.at(0).station_id },
                     });
@@ -120,7 +119,14 @@ const AdminBoxManageTable = () => {
                 >
                   <FaFolderPlus /> 新增紙箱
                 </button>
-                <button className="btn flex items-center gap-1 border p-2">
+                <button
+                  className="btn flex items-center gap-1 border p-2"
+                  onClick={() => {
+                    navigate("/member/admin/tradeBoxes", {
+                      state: { station_id: boxes.at(0).station_id },
+                    });
+                  }}
+                >
                   <FaCashRegister /> 交易紙箱
                 </button>
               </div>

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -5,6 +5,7 @@ import {
   apiGetBoxesTotalForSelling,
   apiUpdateBox,
   apiUpdateMultipleBoxes,
+  apiAddMultipleBoxes,
 } from "@/services/apiBoxes";
 import toast from "react-hot-toast";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -163,4 +164,35 @@ export function useUpdateMultipleBoxes() {
   });
 
   return { updateMultipleBoxes, isUpdating, updatedError, isError };
+}
+
+/**
+ * 自訂 Hook：使用 React Query 來批量新增紙箱資料
+ *
+ * @returns {Object} 返回包含四個屬性的物件：
+ *   - `addMultipleBoxes` {Function} - 用於觸發批量新增的函式，接收 `formData`
+ *   - `isAdding` {boolean} - 是否正在新增資料
+ *   - `addedError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
+ *   - `isError` {boolean} - 是否發生錯誤
+ */
+export function useAddMultipleBoxes() {
+  const queryClient = useQueryClient();
+
+  const {
+    mutate: addMultipleBoxes,
+    error: addedError,
+    isPending: isAdding,
+    isError,
+  } = useMutation({
+    mutationFn: (formData) => apiAddMultipleBoxes(formData),
+    onSuccess: () => {
+      toast.success("紙箱新增成功");
+      queryClient.invalidateQueries({ queryKey: ["boxes"] }); // 重新獲取最新數據
+    },
+    onError: (error) => {
+      toast.error(`新增失敗: ${error.message}`);
+    },
+  });
+
+  return { addMultipleBoxes, isAdding, addedError, isError };
 }

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -207,7 +207,7 @@ export async function apiAddMultipleBoxes(formData) {
       point_value: Number(box.points), // 確保為數字
       retention_days: Number(box.retention_days) || 0, // 轉換為數字
       station_id: formData.station_id, // 站點 ID
-      user_id: formData.userId, // 來自前端的 userId
+      user_id: formData.user_id, // 來自前端的 userId
     }));
 
     // 批量插入數據


### PR DESCRIPTION
### 主要修改
- 封裝：新增多筆紙箱紀錄API 封裝至 `hooks/useBoxes.js/useAddMultipleBoxes`
- 串接：新增多筆紙箱紀錄API
- 更新：5-7 交易紙箱
  - 新增路由：`  <Route path="tradeBoxes" element={<AdminTrade />} />`
  - 點選 5-3 交易紙箱按鈕，將重定向到5-7 交易紙箱表單
  - 部分程式碼以註解方式先隱藏，後續樣式修正交由 @JohnnyHsiehTW 處理

### 次要修改
- supabase boxes中的id欄位設定自動新增編號：`SELECT setval(pg_get_serial_sequence('boxes', 'id'), (SELECT MAX(id) FROM boxes) + 1);`

### 測試方式
- 表單驗證
  - [ ] 會員編號輸入"1234"、'"測試"或"aaa"，出現**新增失敗: 無法新增資料，請確認網路狀態或稍後再試**
  - [ ] 會員編號為空時，出現**會員編號不可為空**
  - [ ] 新增紙箱筆數為無時，出現**至少新增一筆紙箱資料**
- 送出5-6 表單資料
  - [ ] 控制台顯示送出資料（boxes, user_id, station_id)
  - [ ] 畫面跳轉回5-3
  - [ ] 出現新增成功 toast
- 5-7 調整
  - [ ] 從5-3到5-7頁面，控制台是否有顯示stationId? 