### PR TITLE
feat:  4-1 頁面，更新 useMember 回傳會員資料包含交易次數

### DIFF
--- a/src/components/form/MemberInfoForm.jsx
+++ b/src/components/form/MemberInfoForm.jsx
@@ -51,7 +51,6 @@ function MemberInfoForm() {
   //     phone: "+886956135395",
   //     points: 48,
   //     roles: ["users", "storeOwner"],
-  //     transaction_nums: 121,
   //   },
   // };
 

--- a/src/components/table/MemberInfoHistoryTable.jsx
+++ b/src/components/table/MemberInfoHistoryTable.jsx
@@ -1,6 +1,7 @@
 // 4-4 一般會員 - 歷史回收記錄列表
 import DataTable from "react-data-table-component";
 import { customStyles, paginationComponentOptions } from "@/data/constants";
+import { useMemberTransactionRecords } from "@/hooks/useBoxTransactions";
 
 // 假資料
 const tempData = [
@@ -218,7 +219,9 @@ const MemberInfoHistoryTable = () => {
       ),
     },
   ];
-
+  const { records, isLoadingRecords, recordsError } =
+    useMemberTransactionRecords("8b9acdef-b856-4c78-ac16-36d199737957");
+  console.log(records);
   return (
     <DataTable
       columns={columns}

--- a/src/components/table/MemberInfoPointTable.jsx
+++ b/src/components/table/MemberInfoPointTable.jsx
@@ -1,6 +1,7 @@
 // 4-3 一般會員-歷史積分紀錄列表
 import DataTable from "react-data-table-component";
 import { customStyles, paginationComponentOptions } from "@/data/constants";
+import { useMemberTransactionRecords } from "@/hooks/useBoxTransactions";
 
 // 假資料
 const tempData = [
@@ -214,6 +215,10 @@ const MemberInfoPointTable = () => {
       selector: (row) => row.totalPoints,
     },
   ];
+
+  const { records, isLoadingRecords, recordsError } =
+    useMemberTransactionRecords("8b9acdef-b856-4c78-ac16-36d199737957");
+  console.log(records);
 
   return (
     <DataTable

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -1,3 +1,4 @@
+import { apiGetTransactionsCounts } from "./apiBoxTransactions";
 import supabase from "./supabase";
 
 export async function apiSignIn({ email, password }) {
@@ -61,7 +62,9 @@ export async function apiGetMember() {
       data: { user },
     } = await supabase.auth.getUser();
 
-    return user;
+    const transactionsCounts = await apiGetTransactionsCounts(user.id);
+
+    return { user, transactionsCounts };
   } catch (error) {
     throw new Error(error.message);
   }
@@ -75,7 +78,6 @@ export async function apiGetMember() {
 //     phone: "+886956135395",
 //     points: 48,
 //     roles: ["users", "storeOwner"],
-//     transaction_nums: 121,
 //   },
 // };
 export async function apiUpdateMember(newInfoObj) {

--- a/src/services/apiBoxTransactions.js
+++ b/src/services/apiBoxTransactions.js
@@ -15,7 +15,8 @@ export async function apiGetAdminTransactionRecords(stationId) {
     let { data: records, error } = await supabase
       .from("box-transactions")
       .select("*")
-      .eq("station_id", stationId);
+      .eq("station_id", stationId)
+      .order("created_at", { ascending: false });
 
     if (error) throw error;
 
@@ -43,7 +44,8 @@ export async function apiGetMemberTransactionRecords(userId) {
     let { data: records, error } = await supabase
       .from("box-transactions")
       .select("*")
-      .eq("user_id", userId);
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false });
 
     if (error) throw error;
 
@@ -53,5 +55,22 @@ export async function apiGetMemberTransactionRecords(userId) {
     console.error("讀取 box-transactions 發生錯誤:", error);
     // UI 顯示的錯誤內容
     throw new Error("無法取得 box-transactions 資料，請稍後再試");
+  }
+}
+
+export async function apiGetTransactionsCounts(userId) {
+  try {
+    // 交易次數
+    let { data: boxTransactions, error } = await supabase
+      .from("box-transactions")
+      .select("id, user_id")
+      .eq("user_id", userId);
+
+    if (error) throw error;
+
+    const transactionsCounts = boxTransactions.length;
+    return transactionsCounts;
+  } catch (error) {
+    throw new Error(error.message);
   }
 }


### PR DESCRIPTION
### 主要變更：
    - apiBoxTransactions.js ： 新增 apiGetTransactionsCounts 方法，用於會員資訊頁取得交易次數
    - apiAuth.js：更新 apiGetMember 方法，調用 apiGetTransactionsCounts 一起回傳交易次數

### 次要變更：
    - MemberInfoPointTable.jsx：測試調用 useMemberTransactionRecords customer hook
    - MemberInfoHistoryTable.jsx：測試調用 useMemberTransactionRecords customer hook
    - MemberInfoForm.jsx：移除註解欄位

### 異動檔案：
    - modified:   src/components/form/MemberInfoForm.jsx
    - modified:   src/components/table/MemberInfoHistoryTable.jsx
    - modified:   src/components/table/MemberInfoPointTable.jsx
    - modified:   src/services/apiAuth.js
    - modified:   src/services/apiBoxTransactions.js
   
### 測試方法：

- [ ] 進入 MemberInfo.jsx 是否能取得會員資料、交易次數
- [ ] 進入 MemberInfoHistoryTable.jsx 是否能取完整交易記錄
- [ ] 進入 MemberInfoPointTable.jsx 是否能取完整交易記錄
  