### PR TITLE
update

### DIFF
--- a/src/components/MemberNav.jsx
+++ b/src/components/MemberNav.jsx
@@ -4,9 +4,9 @@ const style = {
   mainNavContainer:
     "container mx-auto flex w-full justify-center gap-2 md:justify-start",
   mainNav:
-    "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-white text-[#6F6F6F]",
-  mainNavActive:
     "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-main-600 text-white",
+  mainNavActive:
+    "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-white text-[#6F6F6F]",
   secondNavContainer: "container mx-auto flex gap-2 overflow-x-auto",
   secondNav: "grow py-[23px] text-center text-[#6F6F6F] text-nowrap",
   secondActive:
@@ -39,7 +39,7 @@ function MemberNav() {
               isActive ? style.mainNavActive : style.mainNav
             }
           >
-            <h4>會員頁面</h4>
+            <p className="fs-4">會員頁面</p>
           </NavLink>
           <NavLink
             to="/member/admin"
@@ -47,7 +47,7 @@ function MemberNav() {
               isActive ? style.mainNavActive : style.mainNav
             }
           >
-            <h4>管理者頁面</h4>
+            <p className="fs-4">管理者頁面</p>
           </NavLink>
         </div>
       </nav>

--- a/src/components/dialog/UpdateBoxDialog.jsx
+++ b/src/components/dialog/UpdateBoxDialog.jsx
@@ -11,12 +11,9 @@ import {
 } from "@/components/ui/dialog";
 import UpdateBoxForm from "../form/UpdateBoxForm";
 import { FaPen } from "react-icons/fa";
-import { getExpirationDate, isExpired } from "@/utils/helpers";
 
 function UpdateBoxDialog({ row }) {
   const [open, setOpen] = useState(false);
-  // 保存到期日
-  const retentionDate = getExpirationDate(row.updated_at, row.retention_days);
 
   return (
     <>
@@ -32,24 +29,9 @@ function UpdateBoxDialog({ row }) {
             <DialogTitle>編輯紙箱</DialogTitle>
             <DialogDescription>編輯紙箱資訊</DialogDescription>
           </DialogHeader>
-          <div className="flex gap-2">
-            <img src={row.image_url} alt="照片" className="w-1/4" />
-            <div className="flex flex-col">
-              <p>紙箱編號：{row.id}</p>
-              <p>新增時間：{row.created_at?.replace("T", " ").slice(0, 16)}</p>
-              <p>更新時間：{row.updated_at?.replace("T", " ").slice(0, 16)}</p>
-              <p
-                className={
-                  isExpired(retentionDate) ? "text-red-500" : "text-black"
-                }
-              >
-                保存到期日：
-                {retentionDate}
-              </p>
-              <p>回收會員：{row.user_id?.slice(0, 18)}</p>
-            </div>
+          <div className="max-h-[80vh] overflow-y-auto">
+            <UpdateBoxForm row={row} setOpen={setOpen} />
           </div>
-          <UpdateBoxForm row={row} setOpen={setOpen} />
         </DialogContent>
       </Dialog>
     </>

--- a/src/components/form/UpdateBoxForm.jsx
+++ b/src/components/form/UpdateBoxForm.jsx
@@ -19,6 +19,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useUpdateBox } from "@/hooks/useBoxes";
+import { useState } from "react";
+import supabase from "@/services/supabase";
+import { apiUploadImage } from "@/services/apiBoxes";
 
 UpdateBoxForm.propTypes = { row: PropTypes.object, setOpen: PropTypes.func };
 
@@ -27,21 +30,24 @@ const formSchema = z.object({
   condition: z.string(),
   retention_days: z.number(),
   status: z.string(),
+  image_url: z.string().optional(),
 });
 
 export default function UpdateBoxForm({ row, setOpen }) {
   const { updateBox, isUpdating } = useUpdateBox();
+
   const form = useForm({
     defaultValues: {
       size: row.size,
       condition: row.condition,
       retention_days: row.retention_days,
       status: row.status,
+      image_url: row.image_url,
     },
     resolver: zodResolver(formSchema),
   });
 
-  function onSubmit(values) {
+  async function onSubmit(values) {
     const formattedValues = {
       ...values,
       retention_days: Number(values.retention_days),

--- a/src/components/form/UpdateBoxForm.jsx
+++ b/src/components/form/UpdateBoxForm.jsx
@@ -18,10 +18,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Input } from "../ui/input";
 import { useUpdateBox } from "@/hooks/useBoxes";
-import { useState } from "react";
-import supabase from "@/services/supabase";
 import { apiUploadImage } from "@/services/apiBoxes";
+import { getExpirationDate, isExpired } from "@/utils/helpers";
 
 UpdateBoxForm.propTypes = { row: PropTypes.object, setOpen: PropTypes.func };
 
@@ -30,10 +30,12 @@ const formSchema = z.object({
   condition: z.string(),
   retention_days: z.number(),
   status: z.string(),
-  image_url: z.string().optional(),
+  image: z.instanceof(FileList).optional(),
 });
 
 export default function UpdateBoxForm({ row, setOpen }) {
+  // 保存到期日
+  const retentionDate = getExpirationDate(row.updated_at, row.retention_days);
   const { updateBox, isUpdating } = useUpdateBox();
 
   const form = useForm({
@@ -42,19 +44,38 @@ export default function UpdateBoxForm({ row, setOpen }) {
       condition: row.condition,
       retention_days: row.retention_days,
       status: row.status,
-      image_url: row.image_url,
+      image: undefined,
     },
     resolver: zodResolver(formSchema),
   });
 
   async function onSubmit(values) {
+    const uploadedImage = values.image?.[0] || null;
+    let imageUrl = row.image_url; // 預設使用舊圖片
     const formattedValues = {
-      ...values,
+      size: values.size,
+      condition: values.condition,
       retention_days: Number(values.retention_days),
+      status: values.status,
     };
     try {
-      updateBox({ boxId: row.id, values: formattedValues });
-      console.log(row.id, formattedValues);
+      // 上傳圖片
+      if (uploadedImage) {
+        const res = await apiUploadImage(
+          "box-images",
+          uploadedImage,
+          row.user_id,
+        );
+        const { publicUrl } = await res;
+        imageUrl = publicUrl;
+        console.log("res", res);
+      }
+      // 更新boxes資料
+      await updateBox({
+        boxId: row.id,
+        values: { ...formattedValues, image_url: imageUrl },
+      });
+      console.log("更新成功", row.id, formattedValues);
       setOpen(false);
     } catch (error) {
       console.error("Form submission error", error);
@@ -62,135 +83,179 @@ export default function UpdateBoxForm({ row, setOpen }) {
   }
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-1.5">
-        <FormField
-          control={form.control}
-          name="size"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>紙箱大小</FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={row.size}>
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="特大">特大</SelectItem>
-                  <SelectItem value="大">大</SelectItem>
-                  <SelectItem value="中">中</SelectItem>
-                  <SelectItem value="小">小</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="condition"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>紙箱保存等級</FormLabel>
-              <Select
-                onValueChange={field.onChange}
-                defaultValue={row.condition}
-              >
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="全新">全新</SelectItem>
-                  <SelectItem value="優">優</SelectItem>
-                  <SelectItem value="普通">普通</SelectItem>
-                  <SelectItem value="差">差</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="retention_days"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>紙箱保留天數</FormLabel>
-              <Select
-                onValueChange={(value) => field.onChange(Number(value))}
-                defaultValue={
-                  row.retention_days ? row.retention_days.toString() : "0"
-                }
-              >
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="0" disabled>
-                    0
-                  </SelectItem>
-                  <SelectItem value="7">7</SelectItem>
-                  <SelectItem value="30">30</SelectItem>
-                  <SelectItem value="60">60</SelectItem>
-                  <SelectItem value="90">90</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="status"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>紙箱狀態</FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={row.status}>
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="可認領">可認領</SelectItem>
-                  <SelectItem value="自用">自用</SelectItem>
-                  <SelectItem value="售出">售出</SelectItem>
-                  <SelectItem value="報廢">報廢</SelectItem>
-                  <SelectItem value="保留到期">保留到期</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <div className="flex justify-end gap-2">
-          <button
-            type="button"
-            className="btn-cancel"
-            onClick={() => {
-              setOpen(false);
-              toast.error("取消更新");
-            }}
-          >
-            取消
-          </button>
-          <button type="submit" className="btn" disabled={isUpdating}>
-            {isUpdating ? "更新中" : "確認"}
-          </button>
+    <>
+      <div className="flex gap-4">
+        <div className="overflow-hidden">
+          <img
+            src={row.image_url}
+            alt="照片"
+            className="h-[150px] w-[150px] transition-transform duration-700 hover:scale-150"
+          />
         </div>
-      </form>
-    </Form>
+        <div className="flex flex-col space-y-1">
+          <p>紙箱編號：{row.id}</p>
+          <p>新增時間：{row.created_at?.replace("T", " ").slice(0, 16)}</p>
+          <p>更新時間：{row.updated_at?.replace("T", " ").slice(0, 16)}</p>
+          <p
+            className={isExpired(retentionDate) ? "text-red-500" : "text-black"}
+          >
+            保存到期日：
+            {retentionDate}
+          </p>
+          <p>回收會員：{row.user_id?.slice(0, 18)}</p>
+        </div>
+      </div>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-1.5">
+          <FormField
+            control={form.control}
+            name="image"
+            render={({ field: { onChange, ref } }) => (
+              <FormItem>
+                <FormLabel>紙箱照片</FormLabel>
+                <FormControl>
+                  <Input
+                    type="file"
+                    ref={ref}
+                    onChange={(e) => onChange(e.target.files)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="size"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>紙箱大小</FormLabel>
+                <Select onValueChange={field.onChange} defaultValue={row.size}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="特大">特大</SelectItem>
+                    <SelectItem value="大">大</SelectItem>
+                    <SelectItem value="中">中</SelectItem>
+                    <SelectItem value="小">小</SelectItem>
+                  </SelectContent>
+                </Select>
+
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="condition"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>紙箱保存等級</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={row.condition}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="全新">全新</SelectItem>
+                    <SelectItem value="優">優</SelectItem>
+                    <SelectItem value="普通">普通</SelectItem>
+                    <SelectItem value="差">差</SelectItem>
+                  </SelectContent>
+                </Select>
+
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="retention_days"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>紙箱保留天數</FormLabel>
+                <Select
+                  onValueChange={(value) => field.onChange(Number(value))}
+                  defaultValue={
+                    row.retention_days ? row.retention_days.toString() : "0"
+                  }
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="0" disabled>
+                      0
+                    </SelectItem>
+                    <SelectItem value="7">7</SelectItem>
+                    <SelectItem value="30">30</SelectItem>
+                    <SelectItem value="60">60</SelectItem>
+                    <SelectItem value="90">90</SelectItem>
+                  </SelectContent>
+                </Select>
+
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="status"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>紙箱狀態</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={row.status}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="可認領">可認領</SelectItem>
+                    <SelectItem value="自用">自用</SelectItem>
+                    <SelectItem value="售出">售出</SelectItem>
+                    <SelectItem value="報廢">報廢</SelectItem>
+                    <SelectItem value="保留到期">保留到期</SelectItem>
+                  </SelectContent>
+                </Select>
+
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              className="btn-cancel"
+              onClick={() => {
+                setOpen(false);
+                toast.error("取消更新");
+              }}
+            >
+              取消
+            </button>
+            <button type="submit" className="btn" disabled={isUpdating}>
+              {isUpdating ? "更新中" : "確認"}
+            </button>
+          </div>
+        </form>
+      </Form>
+    </>
   );
 }

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -45,35 +45,50 @@ const AdminBoxManageTable = () => {
 
   // 欄位
   const columns = [
-    { name: "紙箱編號", selector: (row) => row.id, sortable: true },
+    {
+      name: "紙箱編號",
+      selector: (row) => row.id,
+      sortable: true,
+    },
+    { name: "紙箱照片", selector: (row) => <img src={row.image_url} alt="" /> },
     {
       name: "新增時間",
       selector: (row) => row.created_at?.replace("T", " ").slice(0, 16),
       sortable: true,
-      width: "140px",
+      width: "135px",
     },
     {
       name: "更新時間",
       selector: (row) => row.updated_at?.replace("T", " ").slice(0, 16),
       sortable: true,
-      width: "140px",
+      width: "135px",
     },
     { name: "紙箱大小", selector: (row) => row.size, sortable: true },
     {
-      name: "紙箱保存等級",
+      name: "保存等級",
       selector: (row) => row.condition,
       sortable: true,
-      width: "130px",
     },
     {
-      name: "紙箱保留天數",
+      name: "保留天數",
       selector: (row) => row.retention_days,
       sortable: true,
-      width: "130px",
     },
-    { name: "紙箱狀態", selector: (row) => row.status, sortable: true },
-    { name: "對應現金", selector: (row) => row.cash_value, sortable: true },
-    { name: "對應積分", selector: (row) => row.point_value, sortable: true },
+    {
+      name: "紙箱狀態",
+      selector: (row) => row.status,
+      sortable: true,
+    },
+    {
+      name: "對應現金",
+      selector: (row) => row.cash_value,
+      sortable: true,
+    },
+    {
+      name: "對應積分",
+      selector: (row) => row.point_value,
+      sortable: true,
+    },
     {
       name: "編輯",
       selector: (row) => (

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -50,7 +50,12 @@ const AdminBoxManageTable = () => {
       selector: (row) => row.id,
       sortable: true,
     },
-    { name: "紙箱照片", selector: (row) => <img src={row.image_url} alt="" /> },
+    {
+      name: "紙箱照片",
+      selector: (row) => (
+        <img src={row.image_url} alt="" className="h-[70px] w-[70px]" />
+      ),
+    },
     {
       name: "新增時間",
       selector: (row) => row.created_at?.replace("T", " ").slice(0, 16),

--- a/src/components/table/AdminDeprecatedTable.jsx
+++ b/src/components/table/AdminDeprecatedTable.jsx
@@ -44,6 +44,12 @@ const AdminDeprecatedTable = () => {
   const columns = [
     { name: "紙箱編號", selector: (row) => row.id, sortable: true },
     {
+      name: "紙箱照片",
+      selector: (row) => (
+        <img src={row.image_url} alt="" className="h-[70px] w-[70px]" />
+      ),
+    },
+    {
       name: "新增時間",
       selector: (row) => row.created_at?.replace("T", " ").slice(0, 16),
       sortable: true,
@@ -57,16 +63,14 @@ const AdminDeprecatedTable = () => {
     },
     { name: "紙箱大小", selector: (row) => row.size, sortable: true },
     {
-      name: "紙箱保存等級",
+      name: "保存等級",
       selector: (row) => row.condition,
       sortable: true,
-      width: "130px",
     },
     {
-      name: "紙箱保留天數",
+      name: "保留天數",
       selector: (row) => row.retention_days,
       sortable: true,
-      width: "130px",
     },
     { name: "紙箱狀態", selector: (row) => row.status, sortable: true },
     { name: "對應現金", selector: (row) => row.cash_value, sortable: true },

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -228,16 +228,26 @@ export async function apiAddMultipleBoxes(formData) {
   }
 }
 
+// 取得公開 URL
+function getImageUrl(bucket, path) {
+  return supabase.storage.from(bucket).getPublicUrl(path).data.publicUrl;
+}
+
 export async function apiUploadImage(bucket, imageFile, userId) {
   const fileName = `${Date.now()}-${imageFile.name}`.replaceAll("/", "");
+  const filePath = `${userId}/${fileName}`;
+
   try {
+    // 上傳圖片
     const { data, error } = await supabase.storage
       .from(bucket)
-      .upload(`${userId}/${fileName}`, imageFile);
+      .upload(filePath, imageFile);
 
     if (error) throw error;
 
-    return data;
+    // 取得公開 URL
+    const publicUrl = getImageUrl(bucket, filePath);
+    return { data, publicUrl, filePath };
   } catch (error) {
     throw new Error(error.message);
   }

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -227,3 +227,18 @@ export async function apiAddMultipleBoxes(formData) {
     throw new Error("無法新增資料，請確認網路狀態或稍後再試");
   }
 }
+
+export async function apiUploadImage(bucket, imageFile, userId) {
+  const fileName = `${Date.now()}-${imageFile.name}`.replaceAll("/", "");
+  try {
+    const { data, error } = await supabase.storage
+      .from(bucket)
+      .upload(`${userId}/${fileName}`, imageFile);
+
+    if (error) throw error;
+
+    return data;
+  } catch (error) {
+    throw new Error(error.message);
+  }
+}


### PR DESCRIPTION
### 主要修改
- 更新 supabase storage `box-images` policy
- 新增：5-8照片上傳欄位
- 更新：照片上傳API
  - 上傳後取得url，以更新`boxes`的`image_url`
### 次要修改
- 更新：5-3 5-4 新增照片欄位，並微調欄位名稱
- 更新：5-8 dialog 可以上下滾動

### 測試方法
- [x] 找一張紙箱照片，挑一筆紙箱資料上傳照片，然後到supabase storage看看有沒有上傳成功
- [x] 5-3或5-4表單有沒有更新成最新上傳的照片