### PR TITLE
Feature: 完成角色驗證、共用元件拆分與 Header 權限切換

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/is-prop-valid": "^1.3.1",
         "@hookform/resolvers": "^4.0.0",
+        "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.5",
@@ -1208,6 +1209,53 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.3.tgz",
+      "integrity": "sha512-Paen00T4P8L8gd9bNsRMw7Cbaz85oxiv+hzomsRZgFm2byltPFDtfcoqlWJ8GyZlIBWgLssJlzLCnKU0G0302g==",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2922,14 +2970,14 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2940,7 +2988,7 @@
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@emotion/is-prop-valid": "^1.3.1",
     "@hookform/resolvers": "^4.0.0",
+    "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.5",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,8 @@ import MemberInfoHistoryTable from "./components/table/MemberInfoHistoryTable";
 import MemberInfoPointTable from "./components/table/MemberInfoPointTable";
 import AdminTrade from "./components/AdminTrade";
 import AdminAddBoxes from "./components/form/AdminAddBoxes";
+import ProtectedRoute from "./components/ProtectedRoute";
+import AdminProtectedRoute from "./components/AdminProtectedRoute";
 
 const queryClient = new QueryClient();
 
@@ -35,31 +37,41 @@ function App() {
             <Route index element={<Map />} />
             <Route path=":stationId" element={<StationInfo />} />
           </Route>
-          <Route path="member" element={<Member />}>
-            <Route
-              index
-              element={<Navigate replace to="normal/memberInfo" />}
-            />
-            <Route path="normal">
-              <Route index element={<Navigate replace to="memberInfo" />} />
-              <Route path="memberInfo" element={<MemberInfo />} />
-              <Route path="pointsRecords" element={<MemberInfoPointTable />} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="member" element={<Member />}>
               <Route
-                path="transactionRecords"
-                element={<MemberInfoHistoryTable />}
+                index
+                element={<Navigate replace to="normal/memberInfo" />}
               />
-            </Route>
-            <Route path="admin">
-              <Route index element={<Navigate replace to="adminInfo" />} />
-              <Route path="adminInfo" element={<AdminInfo />} />
-              <Route path="boxesTable" element={<AdminBoxManageTable />} />
-              <Route path="addBoxes" element={<AdminAddBoxes />} />
-              <Route path="tradeBoxes" element={<AdminTrade />} />
-              <Route path="recyclingTable" element={<AdminDeprecatedTable />} />
-              <Route
-                path="adminTransactionRecords"
-                element={<AdminTradeHistoryTable />}
-              />
+              <Route path="normal">
+                <Route index element={<Navigate replace to="memberInfo" />} />
+                <Route path="memberInfo" element={<MemberInfo />} />
+                <Route
+                  path="pointsRecords"
+                  element={<MemberInfoPointTable />}
+                />
+                <Route
+                  path="transactionRecords"
+                  element={<MemberInfoHistoryTable />}
+                />
+              </Route>
+              <Route element={<AdminProtectedRoute />}>
+                <Route path="admin">
+                  <Route index element={<Navigate replace to="adminInfo" />} />
+                  <Route path="adminInfo" element={<AdminInfo />} />
+                  <Route path="boxesTable" element={<AdminBoxManageTable />} />
+                  <Route path="addBoxes" element={<AdminAddBoxes />} />
+                  <Route path="tradeBoxes" element={<AdminTrade />} />
+                  <Route
+                    path="recyclingTable"
+                    element={<AdminDeprecatedTable />}
+                  />
+                  <Route
+                    path="adminTransactionRecords"
+                    element={<AdminTradeHistoryTable />}
+                  />
+                </Route>
+              </Route>
             </Route>
           </Route>
           <Route path="signin" element={<Signin />} />

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -1,0 +1,61 @@
+import { Outlet, useLocation } from "react-router-dom";
+
+import { useMember } from "@/hooks/useMember";
+import { useStationAdmin } from "@/hooks/useStationAdmin";
+
+import Banner from "./Banner";
+import DashboardSubNav from "./DashboardSubNav";
+import Spinner from "./Spinner";
+import DashboardNav from "./DashboardNav";
+import BannerImage from "./BannerImage";
+import BannerInfo from "./BannerInfo";
+
+function AdminDashboard({ member }) {
+  const { station, isLoadingStation } = useStationAdmin();
+  const location = useLocation();
+
+  const getNavType = () => {
+    if (location.pathname.startsWith("/member/normal")) {
+      return "normal";
+    } else if (location.pathname.startsWith("/member/admin")) {
+      return "storeOwner";
+    } else {
+      return "normal"; // 預設值
+    }
+  };
+
+  const navType = getNavType();
+
+  if (isLoadingStation) return <Spinner />;
+
+  return (
+    <>
+      <Banner member={member}>
+        <>
+          <BannerInfo
+            title={station.station_name}
+            infoData={[
+              `站點編號：${station.id}`,
+              `地址：${station.address}`,
+              `聯絡電話：${station.phone}`,
+            ]}
+            showApplyButton={false}
+          />
+          <BannerImage
+            role={navType}
+            transactionNums={member.transactionsCounts}
+          />
+        </>
+      </Banner>
+      <main>
+        <DashboardNav role="storeOwner" />
+        <DashboardSubNav role={navType} />
+        <section className="container mx-auto my-10">
+          <Outlet />
+        </section>
+      </main>
+    </>
+  );
+}
+
+export default AdminDashboard;

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -25,20 +25,31 @@ function AdminDashboard({ member }) {
   };
 
   const navType = getNavType();
-
   if (isLoadingStation) return <Spinner />;
+
+  const adminInfo = [
+    `站點編號：${station.id}`,
+    `地址：${station.address}`,
+    `聯絡電話：${station.phone}`,
+  ];
+  const normalInfo = [
+    `會員編號：${member.user.id}`,
+    `電子信箱：${member.user.email}`,
+    `聯絡電話：${member.user.user_metadata.phone}`,
+  ];
 
   return (
     <>
       <Banner member={member}>
         <>
           <BannerInfo
-            title={station.station_name}
-            infoData={[
-              `站點編號：${station.id}`,
-              `地址：${station.address}`,
-              `聯絡電話：${station.phone}`,
-            ]}
+            role={navType}
+            title={
+              navType === "storeOwner"
+                ? station.station_name
+                : member.user.user_metadata.display_name
+            }
+            infoData={navType === "storeOwner" ? adminInfo : normalInfo}
             showApplyButton={false}
           />
           <BannerImage

--- a/src/components/AdminInfo.jsx
+++ b/src/components/AdminInfo.jsx
@@ -24,7 +24,7 @@ const totalBoxes = function (boxes) {
 };
 
 function AdminInfo() {
-  const { station, isLoadingStation } = useStationAdmin();
+  const { station, isLoadingStation } = useStationAdmin(10);
   const { boxes, isLoadingBoxes } = useBoxesTotalForSelling(10);
   if (isLoadingStation) return <Spinner />;
   if (isLoadingBoxes) return <Spinner />;

--- a/src/components/AdminInfo.jsx
+++ b/src/components/AdminInfo.jsx
@@ -1,4 +1,3 @@
-import { useStation } from "@/hooks/useStation";
 import { useBoxesTotalForSelling } from "@/hooks/useBoxes";
 
 import AdminInfoForm from "./form/AdminInfoForm";
@@ -7,6 +6,7 @@ import AdminTradeHistoryTable from "./table/AdminTradeHistoryTable";
 import SellingBoxesCard from "./card/SellingBoxesCard";
 import shop from "@/assets/shop.png";
 import Spinner from "./Spinner";
+import { useStationAdmin } from "@/hooks/useStationAdmin";
 
 const totalBoxes = function (boxes) {
   let small = 0;
@@ -24,7 +24,7 @@ const totalBoxes = function (boxes) {
 };
 
 function AdminInfo() {
-  const { station, isLoadingStation } = useStation(10);
+  const { station, isLoadingStation } = useStationAdmin();
   const { boxes, isLoadingBoxes } = useBoxesTotalForSelling(10);
   if (isLoadingStation) return <Spinner />;
   if (isLoadingBoxes) return <Spinner />;

--- a/src/components/AdminProtectedRoute.jsx
+++ b/src/components/AdminProtectedRoute.jsx
@@ -1,0 +1,13 @@
+import { useMember } from "@/hooks/useMember";
+import { Navigate, Outlet } from "react-router-dom";
+
+function AdminProtectedRoute() {
+  const { role } = useMember();
+
+  if (role === "normal")
+    return <Navigate to="/member/normal/memberInfo" replace />;
+
+  return <Outlet />;
+}
+
+export default AdminProtectedRoute;

--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -1,16 +1,22 @@
 import memberBannerBg01 from "@/assets/memberBanner-bg1.svg";
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 
 function Banner({ children, member }) {
   return (
     <div>
       <section className="bg-[#F3F3F3] bg-top bg-no-repeat md:bg-[url('@/assets/memberBanner-bg2.svg')]">
         <div className="container relative mx-auto flex flex-col items-center gap-10 py-20 text-center md:flex-row md:justify-between md:text-left">
-          <div className="relative h-[201px] w-[200px]">
-            <img
-              src={member.user.user_metadata.avatar_url}
-              alt="會員頭像"
-              className="absolute z-10 rounded-full"
-            />
+          <div className="relative h-[200px] w-[200px] shrink-0">
+            <Avatar className="relative z-10 h-full w-full">
+              <AvatarImage
+                src={member.user.user_metadata.avatar_url}
+                alt={member.user.user_metadata.display_name}
+                className="object-cover"
+              />
+              <AvatarFallback delayMs={600}>
+                {member.user.user_metadata.display_name}
+              </AvatarFallback>
+            </Avatar>
             <img
               src={memberBannerBg01}
               alt="背景圖"

--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -1,0 +1,27 @@
+import memberBannerBg01 from "@/assets/memberBanner-bg1.svg";
+
+function Banner({ children, member }) {
+  return (
+    <div>
+      <section className="bg-[#F3F3F3] bg-top bg-no-repeat md:bg-[url('@/assets/memberBanner-bg2.svg')]">
+        <div className="container relative mx-auto flex flex-col items-center gap-10 py-20 text-center md:flex-row md:justify-between md:text-left">
+          <div className="relative h-[201px] w-[200px]">
+            <img
+              src={member.user.user_metadata.avatar_url}
+              alt="會員頭像"
+              className="absolute z-10 rounded-full"
+            />
+            <img
+              src={memberBannerBg01}
+              alt="背景圖"
+              className="absolute -bottom-3 -left-14 hidden md:flex"
+            />
+          </div>
+          {children}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default Banner;

--- a/src/components/BannerImage.jsx
+++ b/src/components/BannerImage.jsx
@@ -1,0 +1,60 @@
+import box from "@/assets/box.svg";
+import dialog from "@/assets/dialog.svg";
+import { useEffect, useState } from "react";
+
+const memberTitle = {
+  level_1: "相遇路人",
+  level_2: "返箱青年",
+  level_3: "箱村村長",
+  level_4: "箱村守護者",
+};
+
+function BannerImage({ role, transactionNums }) {
+  const [memberLevel, setMemberLevel] = useState(1);
+  const [memberLevelTitle, setMemberLevelTitle] = useState("");
+
+  useEffect(() => {
+    if (transactionNums > 0 && transactionNums < 50) {
+      setMemberLevel(1);
+      setMemberLevelTitle(memberTitle.level_1);
+    } else if (transactionNums >= 50 && transactionNums < 100) {
+      setMemberLevel(2);
+      setMemberLevelTitle(memberTitle.level_2);
+    } else if (transactionNums >= 100 && transactionNums < 200) {
+      setMemberLevel(3);
+      setMemberLevelTitle(memberTitle.level_3);
+    } else if (transactionNums > 200) {
+      setMemberLevel(4);
+      setMemberLevelTitle(memberTitle.level_4);
+    }
+  }, [transactionNums, setMemberLevel]);
+
+  return (
+    <div className="relative h-60 w-80 md:w-[500px]">
+      <h4 className="absolute left-12 top-6 z-30 rotate-6 text-nowrap text-center text-main-100 lg:left-48 lg:top-16">
+        {role === "normal" && (
+          <>
+            {memberLevelTitle}午安，
+            <br />
+            歡迎來到返箱轉運站！
+          </>
+        )}
+        {role === "storeOwner" && (
+          <>
+            站長午安，
+            <br />
+            歡迎回到返箱轉運站！
+          </>
+        )}
+      </h4>
+      <img
+        src={dialog}
+        alt="對話框"
+        className="absolute left-4 z-20 lg:left-40 lg:top-10"
+      />
+      <img src={box} alt="紙箱" className="absolute top-24 z-10" />
+    </div>
+  );
+}
+
+export default BannerImage;

--- a/src/components/BannerInfo.jsx
+++ b/src/components/BannerInfo.jsx
@@ -1,0 +1,22 @@
+import { FaStoreAlt } from "react-icons/fa";
+
+function BannerInfo({ title, infoData = [], showApplyButton }) {
+  return (
+    <div className="grow">
+      <h2 className="mb-4 text-black">{title}</h2>
+      <ul className="fs-6 mb-4 flex flex-col space-y-2 text-[#6F6F6F]">
+        {infoData.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+      {showApplyButton && (
+        <button className="btn flex items-center gap-1 text-main-200">
+          <FaStoreAlt className="text-white" />
+          申請成為轉運站站長
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default BannerInfo;

--- a/src/components/DashboardNav.jsx
+++ b/src/components/DashboardNav.jsx
@@ -1,0 +1,40 @@
+import { NavLink } from "react-router-dom";
+
+const style = {
+  mainNavContainer:
+    "container mx-auto flex w-full justify-center gap-2 md:justify-start",
+  mainNav:
+    "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-white text-[#6F6F6F]",
+  mainNavActive:
+    "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-main-600 text-white",
+};
+
+function DashboardNav({ role }) {
+  return (
+    <nav className="bg-[#F3F3F3]">
+      {/* TabTrigger */}
+      <div className={style.mainNavContainer}>
+        <NavLink
+          to="/member/normal"
+          className={({ isActive }) =>
+            isActive ? style.mainNavActive : style.mainNav
+          }
+        >
+          <h4>會員頁面</h4>
+        </NavLink>
+        {role === "storeOwner" && (
+          <NavLink
+            to="/member/admin"
+            className={({ isActive }) =>
+              isActive ? style.mainNavActive : style.mainNav
+            }
+          >
+            <h4>管理者頁面</h4>
+          </NavLink>
+        )}
+      </div>
+    </nav>
+  );
+}
+
+export default DashboardNav;

--- a/src/components/DashboardNav.jsx
+++ b/src/components/DashboardNav.jsx
@@ -4,9 +4,9 @@ const style = {
   mainNavContainer:
     "container mx-auto flex w-full justify-center gap-2 md:justify-start",
   mainNav:
-    "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-white text-[#6F6F6F]",
-  mainNavActive:
     "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-main-600 text-white",
+  mainNavActive:
+    "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-white text-[#6F6F6F]",
 };
 
 function DashboardNav({ role }) {
@@ -20,7 +20,7 @@ function DashboardNav({ role }) {
             isActive ? style.mainNavActive : style.mainNav
           }
         >
-          <h4>會員頁面</h4>
+          <span className="fs-4">會員頁面</span>
         </NavLink>
         {role === "storeOwner" && (
           <NavLink
@@ -29,7 +29,7 @@ function DashboardNav({ role }) {
               isActive ? style.mainNavActive : style.mainNav
             }
           >
-            <h4>管理者頁面</h4>
+            <span className="fs-4">管理者頁面</span>
           </NavLink>
         )}
       </div>

--- a/src/components/DashboardSubNav.jsx
+++ b/src/components/DashboardSubNav.jsx
@@ -1,0 +1,43 @@
+import { NavLink } from "react-router-dom";
+
+const style = {
+  secondNavContainer: "container mx-auto flex gap-2 overflow-x-auto",
+  secondNav: "grow py-[23px] text-center text-[#6F6F6F] text-nowrap",
+  secondActive:
+    "grow border-b-4 border-main-600 py-[23px] text-center text-main-600 text-nowrap",
+};
+const normalLinks = [
+  { path: "normal/memberInfo", label: "會員頁面" },
+  { path: "normal/pointsRecords", label: "積分紀錄" },
+  { path: "normal/transactionRecords", label: "交易紀錄" },
+];
+
+const adminLinks = [
+  { path: "admin/adminInfo", label: "站點概況" },
+  { path: "admin/boxesTable", label: "可認領紙箱列表" },
+  { path: "admin/recyclingTable", label: "待回收紙箱列表" },
+  { path: "admin/adminTransactionRecords", label: "交易紀錄" },
+];
+function DashboardSubNav({ role }) {
+  const linksArray = role === "storeOwner" ? adminLinks : normalLinks;
+
+  return (
+    <nav className="bg-white">
+      <div className={style.secondNavContainer}>
+        {linksArray.map(({ path, label }) => (
+          <NavLink
+            key={path}
+            to={path}
+            className={({ isActive }) =>
+              isActive ? style.secondActive : style.secondNav
+            }
+          >
+            <h4>{label}</h4>
+          </NavLink>
+        ))}
+      </div>
+    </nav>
+  );
+}
+
+export default DashboardSubNav;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,31 +1,15 @@
-import { useEffect, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import { Link, NavLink } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 import logo from "@/assets/logo.svg";
 import logoSm from "@/assets/logo-sm.svg";
-import MenuLogin from "./MenuLogin";
-import HeaderSignInMenu from "./HeaderSignInMenu";
+import NavMenu from "./NavMenu";
 
 const style = {
   container:
     "container mx-auto flex items-center justify-between px-5 py-2 shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1)] backdrop-blur-[5px] lg:shadow-none lg:backdrop-blur-none",
-  menu: "hidden cursor-pointer md:block lg:hidden",
-  nav: "hidden items-center justify-between gap-6 lg:flex text-nowrap",
-  mapAfter:
-    "after:content text-main-500 after:absolute after:mt-1 after:w-[64px] after:border-b-2 after:border-main-500",
 };
 
 function Header() {
-  const queryClient = useQueryClient();
-  const member = queryClient.getQueryData(["member"])?.user;
-  const [currentMember, setCurrentMember] = useState(null);
-  console.log("Header", currentMember);
-
-  useEffect(() => {
-    if (member) setCurrentMember(member);
-  }, [member, setCurrentMember]);
-
   return (
     <header className="bg-[rgba(255,255,255,0.75)]">
       <div className={style.container}>
@@ -41,36 +25,7 @@ function Header() {
             <img src={logo} alt="紙箱轉運站" height="56" width="235" />
           </picture>
         </Link>
-        <div className="lg:hidden">
-          <MenuLogin
-            currentMember={currentMember}
-            setCurrentMember={setCurrentMember}
-          />
-        </div>
-        <nav className={style.nav}>
-          <NavLink
-            to="/map"
-            className={({ isActive }) => (isActive ? style.mapAfter : "")}
-          >
-            <h6 className="hover:text-main-500">紙箱地圖</h6>
-          </NavLink>
-          {!currentMember && (
-            <NavLink
-              to="/signin"
-              className={({ isActive }) =>
-                isActive ? "btn fs-6 bg-main-500 shadow-none" : "btn"
-              }
-            >
-              登入
-            </NavLink>
-          )}
-          {currentMember && (
-            <HeaderSignInMenu
-              currentMember={currentMember}
-              setCurrentMember={setCurrentMember}
-            />
-          )}
-        </nav>
+        <NavMenu />
       </div>
     </header>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,9 +1,11 @@
+import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Link, NavLink } from "react-router-dom";
+
 import logo from "@/assets/logo.svg";
 import logoSm from "@/assets/logo-sm.svg";
 import MenuLogin from "./MenuLogin";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import HeaderSignInMenu from "./HeaderSignInMenu";
 
 const style = {
   container:
@@ -16,8 +18,14 @@ const style = {
 
 function Header() {
   const queryClient = useQueryClient();
-  const currentMember = queryClient.getQueryData(["member"])?.user;
-  console.log("header", currentMember);
+  const member = queryClient.getQueryData(["member"])?.user;
+  const [currentMember, setCurrentMember] = useState(null);
+  console.log("Header", currentMember);
+
+  useEffect(() => {
+    if (member) setCurrentMember(member);
+  }, [member, setCurrentMember]);
+
   return (
     <header className="bg-[rgba(255,255,255,0.75)]">
       <div className={style.container}>
@@ -34,7 +42,10 @@ function Header() {
           </picture>
         </Link>
         <div className="lg:hidden">
-          <MenuLogin />
+          <MenuLogin
+            currentMember={currentMember}
+            setCurrentMember={setCurrentMember}
+          />
         </div>
         <nav className={style.nav}>
           <NavLink
@@ -54,15 +65,10 @@ function Header() {
             </NavLink>
           )}
           {currentMember && (
-            <>
-              <Avatar>
-                <AvatarImage
-                  src={currentMember.user_metadata.avatar_url}
-                  alt="@shadcn"
-                />
-                <AvatarFallback>CN</AvatarFallback>
-              </Avatar>
-            </>
+            <HeaderSignInMenu
+              currentMember={currentMember}
+              setCurrentMember={setCurrentMember}
+            />
           )}
         </nav>
       </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,9 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { Link, NavLink } from "react-router-dom";
 import logo from "@/assets/logo.svg";
 import logoSm from "@/assets/logo-sm.svg";
 import MenuLogin from "./MenuLogin";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 const style = {
   container:
@@ -13,6 +15,9 @@ const style = {
 };
 
 function Header() {
+  const queryClient = useQueryClient();
+  const currentMember = queryClient.getQueryData(["member"])?.user;
+  console.log("header", currentMember);
   return (
     <header className="bg-[rgba(255,255,255,0.75)]">
       <div className={style.container}>
@@ -38,14 +43,27 @@ function Header() {
           >
             <h6 className="hover:text-main-500">紙箱地圖</h6>
           </NavLink>
-          <NavLink
-            to="/signin"
-            className={({ isActive }) =>
-              isActive ? "btn fs-6 bg-main-500 shadow-none" : "btn"
-            }
-          >
-            登入
-          </NavLink>
+          {!currentMember && (
+            <NavLink
+              to="/signin"
+              className={({ isActive }) =>
+                isActive ? "btn fs-6 bg-main-500 shadow-none" : "btn"
+              }
+            >
+              登入
+            </NavLink>
+          )}
+          {currentMember && (
+            <>
+              <Avatar>
+                <AvatarImage
+                  src={currentMember.user_metadata.avatar_url}
+                  alt="@shadcn"
+                />
+                <AvatarFallback>CN</AvatarFallback>
+              </Avatar>
+            </>
+          )}
         </nav>
       </div>
     </header>

--- a/src/components/HeaderAvatar.jsx
+++ b/src/components/HeaderAvatar.jsx
@@ -1,0 +1,17 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
+
+function HeaderAvatar({ currentMember }) {
+  return (
+    <Avatar>
+      <AvatarImage
+        src={currentMember?.user_metadata?.avatar_url}
+        alt="@shadcn"
+      />
+      <AvatarFallback delayMs={600}>
+        {currentMember?.user_metadata?.display_name}
+      </AvatarFallback>
+    </Avatar>
+  );
+}
+
+export default HeaderAvatar;

--- a/src/components/HeaderAvatar.jsx
+++ b/src/components/HeaderAvatar.jsx
@@ -1,4 +1,4 @@
-import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 
 function HeaderAvatar({ currentMember }) {
   return (

--- a/src/components/HeaderAvatar.jsx
+++ b/src/components/HeaderAvatar.jsx
@@ -5,7 +5,8 @@ function HeaderAvatar({ currentMember }) {
     <Avatar>
       <AvatarImage
         src={currentMember?.user_metadata?.avatar_url}
-        alt="@shadcn"
+        alt={currentMember?.user_metadata?.display_name}
+        className="object-cover"
       />
       <AvatarFallback delayMs={600}>
         {currentMember?.user_metadata?.display_name}

--- a/src/components/HeaderSignInMenu.jsx
+++ b/src/components/HeaderSignInMenu.jsx
@@ -27,7 +27,7 @@ function HeaderSignInMenu({ currentMember, setCurrentMember, role, setRole }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="h-11 w-11 rounded-full px-0">
+        <Button variant="ghost" className="h-11 w-11 rounded-full">
           <HeaderAvatar currentMember={currentMember} />
         </Button>
       </DropdownMenuTrigger>

--- a/src/components/HeaderSignInMenu.jsx
+++ b/src/components/HeaderSignInMenu.jsx
@@ -1,0 +1,70 @@
+import { Link } from "react-router-dom";
+import { useSignOut } from "@/hooks/useSignOut";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { CiLogout } from "react-icons/ci";
+import HeaderAvatar from "./HeaderAvatar";
+
+function HeaderSignInMenu({ currentMember, setCurrentMember }) {
+  const { signOutAsync, isLoading } = useSignOut();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="h-11 w-11 rounded-full px-0">
+          <HeaderAvatar currentMember={currentMember} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="mt-4 w-[200px] sm:mr-14 sm:pr-4">
+        <DropdownMenuLabel>
+          <div className="font-normal leading-[24px]">
+            <p className="text-[#6f6f6f]">
+              {currentMember?.user_metadata?.display_name}, 歡迎回箱
+            </p>
+            <p>{currentMember?.email}</p>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem>
+            <Link
+              to={{
+                pathname: "/member",
+              }}
+            >
+              會員資訊
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem>
+            <Button
+              variant="ghost"
+              className="px-0"
+              onClick={async () => {
+                await signOutAsync();
+                setCurrentMember(null);
+              }}
+              disabled={isLoading}
+            >
+              登出
+            </Button>
+            <DropdownMenuShortcut>
+              <CiLogout />
+            </DropdownMenuShortcut>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export default HeaderSignInMenu;

--- a/src/components/HeaderSignInMenu.jsx
+++ b/src/components/HeaderSignInMenu.jsx
@@ -32,7 +32,7 @@ function HeaderSignInMenu({ currentMember, setCurrentMember, role, setRole }) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        className="mt-3 hidden w-56 text-[#6f6f6f] lg:block"
+        className="relative z-[999] mt-3 hidden w-56 text-[#6f6f6f] lg:block"
         align="end"
       >
         <DropdownMenuLabel>

--- a/src/components/HeaderSignInMenu.jsx
+++ b/src/components/HeaderSignInMenu.jsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import { useSignOut } from "@/hooks/useSignOut";
 
 import { Button } from "@/components/ui/button";
@@ -9,14 +8,21 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+
 import { CiLogout } from "react-icons/ci";
+import { NavLink } from "react-router-dom";
+import { FaUser } from "react-icons/fa";
+
 import HeaderAvatar from "./HeaderAvatar";
 
-function HeaderSignInMenu({ currentMember, setCurrentMember }) {
-  const { signOutAsync, isLoading } = useSignOut();
+const style = {
+  mapAfter:
+    "after:content text-main-500 after:absolute after:left-7 after:bottom-0 after:mt-1 after:w-[64px] after:border-b-2 after:border-main-500",
+};
+function HeaderSignInMenu({ currentMember, setCurrentMember, role, setRole }) {
+  const { signOutAsync } = useSignOut();
 
   return (
     <DropdownMenu>
@@ -25,7 +31,10 @@ function HeaderSignInMenu({ currentMember, setCurrentMember }) {
           <HeaderAvatar currentMember={currentMember} />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="mt-4 w-[200px] sm:mr-14 sm:pr-4">
+      <DropdownMenuContent
+        className="mt-3 hidden w-56 text-[#6f6f6f] lg:block"
+        align="end"
+      >
         <DropdownMenuLabel>
           <div className="font-normal leading-[24px]">
             <p className="text-[#6f6f6f]">
@@ -34,32 +43,33 @@ function HeaderSignInMenu({ currentMember, setCurrentMember }) {
             <p>{currentMember?.email}</p>
           </div>
         </DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        <DropdownMenuGroup>
-          <DropdownMenuItem>
-            <Link
-              to={{
-                pathname: "/member",
-              }}
+        <DropdownMenuSeparator className="h-0 border" />
+        <DropdownMenuGroup className="pt-3">
+          <DropdownMenuItem className="my-0 mb-3 p-0">
+            <NavLink
+              to="/member"
+              className={({ isActive }) =>
+                `${isActive ? style.mapAfter : "text-[#6F6F6F]"} flex w-full items-center gap-2 px-2 py-3 hover:text-main-500`
+              }
             >
-              會員資訊
-            </Link>
+              <FaUser />
+              {role === "storeOwner" ? "會員資訊 & 站點管理" : "會員資訊"}
+            </NavLink>
           </DropdownMenuItem>
-          <DropdownMenuItem>
+
+          <DropdownMenuItem className="my-0 mb-3 p-0">
             <Button
               variant="ghost"
-              className="px-0"
+              className="w-full justify-start px-2 py-5 hover:text-main-500"
               onClick={async () => {
                 await signOutAsync();
                 setCurrentMember(null);
+                setRole("");
               }}
-              disabled={isLoading}
             >
+              <CiLogout />
               登出
             </Button>
-            <DropdownMenuShortcut>
-              <CiLogout />
-            </DropdownMenuShortcut>
           </DropdownMenuItem>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -20,6 +20,7 @@ import Spinner from "@/components/Spinner";
 import ErrorMessage from "./ErrorMessage";
 import mapMark from "../assets/mapMark.png";
 import SellingBoxesCard from "./card/SellingBoxesCard";
+import { getPendingBoxes } from "@/utils/helpers";
 
 // 取得使用者定位
 const UserLocation = ({ setUserLocation }) => {
@@ -46,9 +47,23 @@ const UserLocation = ({ setUserLocation }) => {
 };
 
 // 建議站點卡
-const SuggestionStationCard = ({ station, countRecyclableBoxes, countPendingBoxes, formatPhoneNumber, setClickedId, mapRef, setIsStationInfo, isLg, setIsSideBar, markerRefs, setPopupStation }) => {
+const SuggestionStationCard = ({
+  station,
+  countRecyclableBoxes,
+  countPendingBoxes,
+  formatPhoneNumber,
+  setClickedId,
+  mapRef,
+  setIsStationInfo,
+  isLg,
+  setIsSideBar,
+  markerRefs,
+  setPopupStation,
+}) => {
   const { latitude, longitude } = station; //取得經緯度
   const [isBoxSize, setIsBoxSize] = useState(false); //開啟查看紙箱尺寸
+
+  const countsObj = getPendingBoxes(station.boxes);
 
   //前往選擇站點定位
   const handleCheckStation = () => {
@@ -70,7 +85,7 @@ const SuggestionStationCard = ({ station, countRecyclableBoxes, countPendingBoxe
   };
 
   return (
-    <div className="p-[24px] border rounded-lg">
+    <div className="rounded-lg border p-[24px]">
       <button onClick={() => handleCheckStation()}>
         <h5 className="mb-[12px]">{station.station_name}</h5>
       </button>
@@ -93,41 +108,38 @@ const SuggestionStationCard = ({ station, countRecyclableBoxes, countPendingBoxe
 
       <ul className="fs-6 mb-[12px] flex flex-col gap-[12px] text-[#6F6F6F]">
         <li className="flex items-start justify-start gap-[8px]">
-          <span className="material-symbols-outlined">
-            location_on
-          </span>
+          <span className="material-symbols-outlined">location_on</span>
           {`地址:${station.address}`}
         </li>
         <li className="flex items-start justify-start gap-[8px]">
           <span className="material-symbols-outlined">call</span>
-          {`電話:${station.phone ? formatPhoneNumber(station.phone) : '尚未填寫'}`}
+          {`電話:${station.phone ? formatPhoneNumber(station.phone) : "尚未填寫"}`}
         </li>
       </ul>
 
       <div className="mb-[24px] rounded-lg border border-solid border-[#B7B7B7] p-[16px]">
         <h6 className="mb-[12px]">回收認領資訊</h6>
 
-        <div className="mb-[12px] flex flex-col lg:flex-row justify-center gap-[8px]">
+        <div className="mb-[12px] flex flex-col justify-center gap-[8px] lg:flex-row">
           {/* 可回收 */}
           <div className="w-full">
             <p className="mb-[8px] w-full rounded-lg bg-main-100 py-[4px] text-center text-main-600">
               可回收紙箱
             </p>
-            <div className="flex gap-[4px] w-full">
-
-              <div className="flex flex-col items-center rounded-lg bg-main-100 p-[6px] text-main-600 w-full">
+            <div className="flex w-full gap-[4px]">
+              <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[6px] text-main-600">
                 <h4>{station.available_slots.S}</h4>
                 <p>S</p>
               </div>
-              <div className="flex flex-col items-center rounded-lg bg-main-100 p-[6px] text-main-600 w-full">
+              <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[6px] text-main-600">
                 <h4>{station.available_slots.M}</h4>
                 <p>M</p>
               </div>
-              <div className="flex flex-col items-center rounded-lg bg-main-100 p-[6px] text-main-600 w-full">
+              <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[6px] text-main-600">
                 <h4>{station.available_slots.L}</h4>
                 <p>L</p>
               </div>
-              <div className="flex flex-col items-center rounded-lg bg-main-100 p-[6px] text-main-600 w-full">
+              <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[6px] text-main-600">
                 <h4>{station.available_slots.XL}</h4>
                 <p>XL</p>
               </div>
@@ -138,21 +150,21 @@ const SuggestionStationCard = ({ station, countRecyclableBoxes, countPendingBoxe
             <p className="text-second-600 mb-[8px] w-full rounded-lg bg-second-100 py-[4px] text-center">
               可認領紙箱
             </p>
-            <div className="flex gap-[4px] w-full">
-              <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[6px] w-full">
-                <h4>{station.pending_boxes_s}</h4>
+            <div className="flex w-full gap-[4px]">
+              <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[6px]">
+                <h4>{countsObj["小"] || 0}</h4>
                 <p>S</p>
               </div>
-              <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[6px] w-full">
-                <h4>{station.pending_boxes_m}</h4>
+              <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[6px]">
+                <h4>{countsObj["中"] || 0}</h4>
                 <p>M</p>
               </div>
-              <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[6px] w-full">
-                <h4>{station.pending_boxes_l}</h4>
+              <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[6px]">
+                <h4>{countsObj["大"] || 0}</h4>
                 <p>L</p>
               </div>
-              <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[6px] w-full">
-                <h4>{station.pending_boxes_xl}</h4>
+              <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[6px]">
+                <h4>{countsObj["特大"] || 0}</h4>
                 <p>XL</p>
               </div>
             </div>
@@ -186,25 +198,36 @@ const SuggestionStationCard = ({ station, countRecyclableBoxes, countPendingBoxe
         </div>
       </div>
 
-      <div className="flex gap-[12px] md:flex-row flex-col text-center">
-        <button className="btn" onClick={() => {
-          setClickedId(station.id)
-          setIsStationInfo(true)
-        }}>站點資訊</button>
+      <div className="flex flex-col gap-[12px] text-center md:flex-row">
+        <button
+          className="btn"
+          onClick={() => {
+            setClickedId(station.id);
+            setIsStationInfo(true);
+          }}
+        >
+          站點資訊
+        </button>
         <NavLink className="btn" to={`/map/${station.id}`}>
           查看本站紙箱列表
         </NavLink>
       </div>
-
     </div>
-  )
-}
+  );
+};
 
 //側邊欄站點詳細資訊
-const StationDetailedInfo = ({ station, countRecyclableBoxes, countPendingBoxes, formatPhoneNumber, handleBackSuggestaion }) => {
-
+const StationDetailedInfo = ({
+  station,
+  countRecyclableBoxes,
+  countPendingBoxes,
+  formatPhoneNumber,
+  handleBackSuggestaion,
+}) => {
   const [isAllOpenTime, setIsAllOpenTime] = useState(false); //開啟詳細營業時間
   const [isBoxSize, setIsBoxSize] = useState(false); //開啟查看紙箱尺寸
+
+  const countsObj = getPendingBoxes(station.boxes);
 
   // 取得一週的營業時間
   const formatOpenTime = (station_daily_hours) => {
@@ -213,19 +236,47 @@ const StationDetailedInfo = ({ station, countRecyclableBoxes, countPendingBoxes,
       const closeTime = item.close_time.replace(/^(\d{2}:\d{2}):\d{2}.*/, "$1");
 
       if (index === 0) {
-        return <li key={index}>{item ? `星期日 ${openTime}-${closeTime}` : '休息'}</li>;
+        return (
+          <li key={index}>
+            {item ? `星期日 ${openTime}-${closeTime}` : "休息"}
+          </li>
+        );
       } else if (index === 1) {
-        return <li key={index}>{item ? `星期一 ${openTime}-${closeTime}` : '休息'}</li>;
+        return (
+          <li key={index}>
+            {item ? `星期一 ${openTime}-${closeTime}` : "休息"}
+          </li>
+        );
       } else if (index === 2) {
-        return <li key={index}>{item ? `星期二 ${openTime}-${closeTime}` : '休息'}</li>;
+        return (
+          <li key={index}>
+            {item ? `星期二 ${openTime}-${closeTime}` : "休息"}
+          </li>
+        );
       } else if (index === 3) {
-        return <li key={index}>{item ? `星期三 ${openTime}-${closeTime}` : '休息'}</li>;
+        return (
+          <li key={index}>
+            {item ? `星期三 ${openTime}-${closeTime}` : "休息"}
+          </li>
+        );
       } else if (index === 4) {
-        return <li key={index}>{item ? `星期四 ${openTime}-${closeTime}` : '休息'}</li>;
+        return (
+          <li key={index}>
+            {item ? `星期四 ${openTime}-${closeTime}` : "休息"}
+          </li>
+        );
       } else if (index === 5) {
-        return <li key={index}>{item ? `星期五 ${openTime}-${closeTime}` : '休息'}</li>;
+        return (
+          <li key={index}>
+            {item ? `星期五 ${openTime}-${closeTime}` : "休息"}
+          </li>
+        );
       } else {
-        return <li key={index}>{item ? `星期六 ${openTime}-${closeTime}` : '休息'}</li>;
+        return (
+          <li key={index}>
+            {item ? `星期六 ${openTime}-${closeTime}` : "休息"}
+          </li>
+        );
       }
     });
   };
@@ -245,126 +296,46 @@ const StationDetailedInfo = ({ station, countRecyclableBoxes, countPendingBoxes,
     return todayOpenTime;
   };
 
-  return (<div>
-    <img
-      src={station.image_url}
-      alt={station.station_name}
-      className="w-full object-cover"
-    />
-    <div className="p-[24px]">
-      <h5 className="mb-[12px]">{station.station_name}</h5>
-      <h5 className="mb-[12px] flex gap-[8px] text-base">
-        {countRecyclableBoxes(station) ? (
-          <span className="fs-7 rounded-full bg-main-200 px-[12px] py-[4px]">
-            可回收
-          </span>
-        ) : (
-          <></>
-        )}
-        {countPendingBoxes(station) ? (
-          <span className="fs-7 rounded-full bg-second-200 px-[12px] py-[4px]">
-            可認領
-          </span>
-        ) : (
-          <></>
-        )}
-      </h5>
+  return (
+    <div>
+      <img
+        src={station.image_url}
+        alt={station.station_name}
+        className="w-full object-cover"
+      />
+      <div className="p-[24px]">
+        <h5 className="mb-[12px]">{station.station_name}</h5>
+        <h5 className="mb-[12px] flex gap-[8px] text-base">
+          {countRecyclableBoxes(station) ? (
+            <span className="fs-7 rounded-full bg-main-200 px-[12px] py-[4px]">
+              可回收
+            </span>
+          ) : (
+            <></>
+          )}
+          {countPendingBoxes(station) ? (
+            <span className="fs-7 rounded-full bg-second-200 px-[12px] py-[4px]">
+              可認領
+            </span>
+          ) : (
+            <></>
+          )}
+        </h5>
 
-      <ul className="fs-6 mb-[12px] flex flex-col gap-[12px] text-[#6F6F6F]">
-        <li className="flex items-start justify-start gap-[8px]">
-          <span className="material-symbols-outlined">
-            location_on
-          </span>
-          {`地址:${station.address}`}
-        </li>
-        <li className="flex items-start justify-start gap-[8px]">
-          <span className="material-symbols-outlined">call</span>
-          {`電話:${station.phone ? formatPhoneNumber(station.phone) : '尚未填寫'}`}
-        </li>
-        <li className="flex items-start justify-start gap-[8px]">
-          <span className="material-symbols-outlined">
-            schedule
-          </span>
-          <p>{`營業時間:${getTodayOpenTime(station.station_daily_hours)}`}</p>
-          <button onClick={() => setIsAllOpenTime(!isAllOpenTime)}>
-            {isAllOpenTime ? (
-              <span className="material-symbols-outlined">
-                keyboard_arrow_up
-              </span>
-            ) : (
-              <span className="material-symbols-outlined">
-                keyboard_arrow_down
-              </span>
-            )}
-          </button>
-        </li>
-        {isAllOpenTime && (
-          <ul className="flex w-full flex-col items-center gap-[8px]">
-            {formatOpenTime(station.station_daily_hours)}
-          </ul>
-        )}
-      </ul>
-
-      <div className="mb-[24px] rounded-lg border border-solid border-[#B7B7B7] p-[16px]">
-        <h6 className="mb-[12px]">回收認領資訊</h6>
-
-        <div className="mb-[12px] flex flex-col lg:flex-row justify-center gap-[25px]">
-          {/* 可回收 */}
-          <div>
-            <p className="mb-[8px] w-full rounded-lg bg-main-100 py-[4px] text-center text-main-600">
-              可回收紙箱
-            </p>
-            <div className="flex gap-[8px]">
-
-              <div className="flex flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600 w-full">
-                <h4>{station.available_slots.S}</h4>
-                <p>S</p>
-              </div>
-              <div className="flex flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600 w-full">
-                <h4>{station.available_slots.M}</h4>
-                <p>M</p>
-              </div>
-              <div className="flex flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600 w-full">
-                <h4>{station.available_slots.L}</h4>
-                <p>L</p>
-              </div>
-              <div className="flex flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600 w-full">
-                <h4>{station.available_slots.XL}</h4>
-                <p>XL</p>
-              </div>
-            </div>
-          </div>
-          {/* 可認領 */}
-          <div>
-            <p className="text-second-600 mb-[8px] w-full rounded-lg bg-second-100 py-[4px] text-center">
-              可認領紙箱
-            </p>
-            <div className="flex gap-[8px]">
-              <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[8px] w-full">
-                <h4>{station.pending_boxes_s}</h4>
-                <p>S</p>
-              </div>
-              <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[8px] w-full">
-                <h4>{station.pending_boxes_m}</h4>
-                <p>M</p>
-              </div>
-              <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[8px] w-full">
-                <h4>{station.pending_boxes_l}</h4>
-                <p>L</p>
-              </div>
-              <div className="text-second-600 flex flex-col items-center rounded-lg bg-second-100 p-[8px] w-full">
-                <h4>{station.pending_boxes_xl}</h4>
-                <p>XL</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="border-t border-[#B7B7B7] pt-[12px]">
-          <div className="flex justify-between">
-            <p>查看紙箱尺寸</p>
-            <button onClick={() => setIsBoxSize(!isBoxSize)}>
-              {isBoxSize ? (
+        <ul className="fs-6 mb-[12px] flex flex-col gap-[12px] text-[#6F6F6F]">
+          <li className="flex items-start justify-start gap-[8px]">
+            <span className="material-symbols-outlined">location_on</span>
+            {`地址:${station.address}`}
+          </li>
+          <li className="flex items-start justify-start gap-[8px]">
+            <span className="material-symbols-outlined">call</span>
+            {`電話:${station.phone ? formatPhoneNumber(station.phone) : "尚未填寫"}`}
+          </li>
+          <li className="flex items-start justify-start gap-[8px]">
+            <span className="material-symbols-outlined">schedule</span>
+            <p>{`營業時間:${getTodayOpenTime(station.station_daily_hours)}`}</p>
+            <button onClick={() => setIsAllOpenTime(!isAllOpenTime)}>
+              {isAllOpenTime ? (
                 <span className="material-symbols-outlined">
                   keyboard_arrow_up
                 </span>
@@ -374,63 +345,163 @@ const StationDetailedInfo = ({ station, countRecyclableBoxes, countPendingBoxes,
                 </span>
               )}
             </button>
-          </div>
-          {isBoxSize ? (
-            <ul className="list-inside list-disc text-[#6F6F6F]">
-              <li>小紙箱：總長 50 公分以下</li>
-              <li>中紙箱：總長 50 ~ 120 公分</li>
-              <li>大紙箱：總長 120 公分以上</li>
+          </li>
+          {isAllOpenTime && (
+            <ul className="flex w-full flex-col items-center gap-[8px]">
+              {formatOpenTime(station.station_daily_hours)}
             </ul>
-          ) : (
-            <></>
           )}
+        </ul>
+
+        <div className="mb-[24px] rounded-lg border border-solid border-[#B7B7B7] p-[16px]">
+          <h6 className="mb-[12px]">回收認領資訊</h6>
+
+          <div className="mb-[12px] flex flex-col justify-center gap-[25px] lg:flex-row">
+            {/* 可回收 */}
+            <div>
+              <p className="mb-[8px] w-full rounded-lg bg-main-100 py-[4px] text-center text-main-600">
+                可回收紙箱
+              </p>
+              <div className="flex gap-[8px]">
+                <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                  <h4>{station.available_slots.S}</h4>
+                  <p>S</p>
+                </div>
+                <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                  <h4>{station.available_slots.M}</h4>
+                  <p>M</p>
+                </div>
+                <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                  <h4>{station.available_slots.L}</h4>
+                  <p>L</p>
+                </div>
+                <div className="flex w-full flex-col items-center rounded-lg bg-main-100 p-[8px] text-main-600">
+                  <h4>{station.available_slots.XL}</h4>
+                  <p>XL</p>
+                </div>
+              </div>
+            </div>
+            {/* 可認領 */}
+            <div>
+              <p className="text-second-600 mb-[8px] w-full rounded-lg bg-second-100 py-[4px] text-center">
+                可認領紙箱
+              </p>
+              <div className="flex gap-[8px]">
+                <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[8px]">
+                  <h4>{countsObj["小"] || 0}</h4>
+                  <p>S</p>
+                </div>
+                <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[8px]">
+                  <h4>{countsObj["中"] || 0}</h4>
+                  <p>M</p>
+                </div>
+                <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[8px]">
+                  <h4>{countsObj["大"] || 0}</h4>
+                  <p>L</p>
+                </div>
+                <div className="text-second-600 flex w-full flex-col items-center rounded-lg bg-second-100 p-[8px]">
+                  <h4>{countsObj["特大"] || 0}</h4>
+                  <p>XL</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="border-t border-[#B7B7B7] pt-[12px]">
+            <div className="flex justify-between">
+              <p>查看紙箱尺寸</p>
+              <button onClick={() => setIsBoxSize(!isBoxSize)}>
+                {isBoxSize ? (
+                  <span className="material-symbols-outlined">
+                    keyboard_arrow_up
+                  </span>
+                ) : (
+                  <span className="material-symbols-outlined">
+                    keyboard_arrow_down
+                  </span>
+                )}
+              </button>
+            </div>
+            {isBoxSize ? (
+              <ul className="list-inside list-disc text-[#6F6F6F]">
+                <li>小紙箱：總長 50 公分以下</li>
+                <li>中紙箱：總長 50 ~ 120 公分</li>
+                <li>大紙箱：總長 120 公分以上</li>
+              </ul>
+            ) : (
+              <></>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-col gap-[8px] text-center md:flex-row">
+          <NavLink className="btn" to={`/map/${station.id}`}>
+            查看本站紙箱列表
+          </NavLink>
+          <button className="btn" onClick={() => handleBackSuggestaion()}>
+            返回搜尋結果
+          </button>
         </div>
       </div>
-      <div className="flex gap-[8px] md:flex-row flex-col text-center">
-        <NavLink className="btn" to={`/map/${station.id}`}>
-          查看本站紙箱列表
-        </NavLink>
-        <button className="btn" onClick={() => handleBackSuggestaion()}>
-          返回搜尋結果
-        </button>
-      </div>
     </div>
-  </div>)
-}
+  );
+};
 
 //Popup
-const PopupCardLg = ({ station, countRecyclableBoxes, countPendingBoxes, setIsStationInfo, setIsSideBar, setClickedId }) => {
-  return (<div>
-    <h6 className="mb-[12px] text-start font-semibold">
-      {station.station_name}
-    </h6>
-    <div className="flex justify-center gap-[8px]">
-      <span className="fs-7 rounded-full bg-main-200 px-[12px] py-[4px]">{`可回收${countRecyclableBoxes(station)}個`}</span>
-      <span className="fs-7 rounded-full bg-second-200 px-[12px] py-[4px]">{`可認領${countPendingBoxes(station)}個`}</span>
+const PopupCardLg = ({
+  station,
+  countRecyclableBoxes,
+  countPendingBoxes,
+  setIsStationInfo,
+  setIsSideBar,
+  setClickedId,
+}) => {
+  return (
+    <div>
+      <h6 className="mb-[12px] text-start font-semibold">
+        {station.station_name}
+      </h6>
+      <div className="flex justify-center gap-[8px]">
+        <span className="fs-7 rounded-full bg-main-200 px-[12px] py-[4px]">{`可回收${countRecyclableBoxes(station)}個`}</span>
+        <span className="fs-7 rounded-full bg-second-200 px-[12px] py-[4px]">{`可認領${countPendingBoxes(station)}個`}</span>
+      </div>
+      <p className="mb-[12px]">{station.address}</p>
+      <button
+        className="btn w-full"
+        onClick={() => {
+          setClickedId(station.id);
+          setIsStationInfo(true);
+          setIsSideBar(true);
+        }}
+      >
+        站點資訊
+      </button>
     </div>
-    <p className="mb-[12px]">{station.address}</p>
-    <button className="btn w-full" onClick={() => {
-      setClickedId(station.id);
-      setIsStationInfo(true);
-      setIsSideBar(true);
-    }}>站點資訊</button>
-  </div>)
-}
+  );
+};
 
 const PopupCard = ({ station, countRecyclableBoxes, countPendingBoxes }) => {
-  return (<div>
-    <h6 className="mb-[12px] text-start font-semibold">
-      {station.station_name}
-    </h6>
-    <div className="flex justify-center gap-[8px]">
-      {countRecyclableBoxes(station) && (<span className="fs-7 rounded-full bg-main-200 px-[12px] py-[4px]">可回收</span>)}
-      {countPendingBoxes(station) && (<span className="fs-7 rounded-full bg-second-200 px-[12px] py-[4px]">可認領</span>)}
-      {/* <span className="fs-7 rounded-full bg-main-200 px-[12px] py-[4px]">{`可回收${countRecyclableBoxes(station)}個`}</span>
+  return (
+    <div>
+      <h6 className="mb-[12px] text-start font-semibold">
+        {station.station_name}
+      </h6>
+      <div className="flex justify-center gap-[8px]">
+        {countRecyclableBoxes(station) && (
+          <span className="fs-7 rounded-full bg-main-200 px-[12px] py-[4px]">
+            可回收
+          </span>
+        )}
+        {countPendingBoxes(station) && (
+          <span className="fs-7 rounded-full bg-second-200 px-[12px] py-[4px]">
+            可認領
+          </span>
+        )}
+        {/* <span className="fs-7 rounded-full bg-main-200 px-[12px] py-[4px]">{`可回收${countRecyclableBoxes(station)}個`}</span>
       <span className="fs-7 rounded-full bg-second-200 px-[12px] py-[4px]">{`可認領${countPendingBoxes(station)}個`}</span> */}
+      </div>
     </div>
-  </div>)
-}
-
+  );
+};
 
 function Map() {
   const mapRef = useRef(null); //取得地圖實例
@@ -439,18 +510,16 @@ function Map() {
   const { stations, isLoadingStations, stationsError } = useStations(); //全部站點
   const { station, isLoadingStation, stationError } = useStation(clickedId); //所選擇的站點詳細資訊
 
-
   const [isSideBar, setIsSideBar] = useState(false); //開啟SideBar
-  const [isStationInfo, setIsStationInfo] = useState(false);//開啟側邊欄站點資訊
+  const [isStationInfo, setIsStationInfo] = useState(false); //開啟側邊欄站點資訊
   const [userLocation, setUserLocation] = useState([]); //儲存使用者定位
   const [suggestionStations, setSuggestionStations] = useState([]); //儲存5筆鄰近站點
-  const [popupStation, setPopupStation] = useState({});//儲存Popup站點資訊
-  const [searchKeyWords, setSearchKeyWords] = useState('');//儲存使用者輸入的搜尋關鍵字
-  const [availableTags, setAvailableTags] = useState([]);//儲存搜尋建議tags
-  const [showSuggestedTags, setShowSuggestedTags] = useState(false);//顯示建議選項
+  const [popupStation, setPopupStation] = useState({}); //儲存Popup站點資訊
+  const [searchKeyWords, setSearchKeyWords] = useState(""); //儲存使用者輸入的搜尋關鍵字
+  const [availableTags, setAvailableTags] = useState([]); //儲存搜尋建議tags
+  const [showSuggestedTags, setShowSuggestedTags] = useState(false); //顯示建議選項
   const [isLg, setIsLg] = useState(false); //畫面大小
   const markerRefs = useRef({}); //儲存所有的marker
-
 
   // 取得5筆鄰近站點
   useEffect(() => {
@@ -464,7 +533,7 @@ function Map() {
     if (stations) {
       getAvailableTags();
     }
-  }, [stations])
+  }, [stations]);
 
   // 畫面大小
   useEffect(() => {
@@ -480,11 +549,10 @@ function Map() {
 
     checkSize(); // 初始化檢查
 
-    window.addEventListener('resize', checkSize); // 當螢幕大小改變時更新狀態
+    window.addEventListener("resize", checkSize); // 當螢幕大小改變時更新狀態
 
-    return () => window.removeEventListener('resize', checkSize);
+    return () => window.removeEventListener("resize", checkSize);
   }, []);
-
 
   if (isLoadingStations) return <Spinner />;
   if (stationsError) return <ErrorMessage error={stationsError} />;
@@ -500,14 +568,8 @@ function Map() {
     );
   };
 
-  const countPendingBoxes = (station) => {
-    return (
-      station.pending_boxes_xl +
-      station.pending_boxes_l +
-      station.pending_boxes_m +
-      station.pending_boxes_s
-    );
-  };
+  const countPendingBoxes = (station) => station.boxes?.length;
+
   // 電話國際碼轉換市碼
   const formatPhoneNumber = (phone) => {
     return phone?.replace(/^\+886-/, "0").replace(/#$/, "");
@@ -528,10 +590,9 @@ function Map() {
              </div>`,
       iconSize: [40, 41], // 調整圖標大小
       iconAnchor: [20, 41], // 調整圖標的錨點
-      popupAnchor: [0, -41] // 調整彈出視窗位置
+      popupAnchor: [0, -41], // 調整彈出視窗位置
     });
   };
-  
 
   // 回到使用者定位
   const handleLocateUser = () => {
@@ -545,12 +606,15 @@ function Map() {
   const countDistance = () => {
     const allDistance = stations.map((item) => ({
       ...item,
-      distance: L.latLng(userLocation[0], userLocation[1]).distanceTo(L.latLng(item.latitude, item.longitude))
-    }
-    ))
+      distance: L.latLng(userLocation[0], userLocation[1]).distanceTo(
+        L.latLng(item.latitude, item.longitude),
+      ),
+    }));
 
-    setSuggestionStations(allDistance.sort((a, b) => a.distance - b.distance).slice(0, 5));
-  }
+    setSuggestionStations(
+      allDistance.sort((a, b) => a.distance - b.distance).slice(0, 5),
+    );
+  };
 
   //返回建議站點列表
   const handleBackSuggestaion = () => {
@@ -560,18 +624,22 @@ function Map() {
       const map = mapRef.current;
       map.closePopup();
     }
-  }
+  };
 
   //執行搜尋
   const handleSearchStations = (e) => {
     e.preventDefault();
-    const matchStations = stations.filter((item) => item.station_name.includes(searchKeyWords) || item.address.includes(searchKeyWords));
+    const matchStations = stations.filter(
+      (item) =>
+        item.station_name.includes(searchKeyWords) ||
+        item.address.includes(searchKeyWords),
+    );
     setSuggestionStations(matchStations);
-    setSearchKeyWords('');
+    setSearchKeyWords("");
     setIsSideBar(true);
     setShowSuggestedTags(false);
     setIsStationInfo(false);
-  }
+  };
 
   //取得搜尋建議tags
   const getAvailableTags = () => {
@@ -586,35 +654,37 @@ function Map() {
     setPopupStation(item); // 設定選中的站點
     if (!isLg) {
       // 在小螢幕上直接開啟側邊欄
-      setClickedId(item.id)
+      setClickedId(item.id);
       setIsStationInfo(true);
       setIsSideBar(true);
     }
   };
 
-
   return (
     <>
-      <MapNav handleLocateUser={handleLocateUser}
+      <MapNav
+        handleLocateUser={handleLocateUser}
         searchKeyWords={searchKeyWords}
         setSearchKeyWords={setSearchKeyWords}
         handleSearchStations={handleSearchStations}
         availableTags={availableTags}
         showSuggestedTags={showSuggestedTags}
-        setShowSuggestedTags={setShowSuggestedTags} />
+        setShowSuggestedTags={setShowSuggestedTags}
+      />
 
-      <div
-        className="relative mx-auto flex justify-between lg:flex-row lg:h-[700px] "
-      >
+      <div className="relative mx-auto flex justify-between lg:h-[700px] lg:flex-row">
         {/* 側邊欄 */}
         {isSideBar ? (
-          <div className="lg:w-[486px] w-full flex-shrink-0 overflow-auto scrollbar">
-            <button className="lg:hidden flex gap-[12px] py-[24px] px-[24px]" onClick={() => setIsSideBar(false)}><span className="material-symbols-outlined">
-              arrow_back
-            </span><h5>回到地圖</h5></button>
+          <div className="scrollbar w-full flex-shrink-0 overflow-auto lg:w-[486px]">
+            <button
+              className="flex gap-[12px] px-[24px] py-[24px] lg:hidden"
+              onClick={() => setIsSideBar(false)}
+            >
+              <span className="material-symbols-outlined">arrow_back</span>
+              <h5>回到地圖</h5>
+            </button>
 
             {isStationInfo && station ? (
-
               <StationDetailedInfo
                 station={station}
                 countRecyclableBoxes={countRecyclableBoxes}
@@ -622,12 +692,12 @@ function Map() {
                 formatPhoneNumber={formatPhoneNumber}
                 handleBackSuggestaion={handleBackSuggestaion}
               ></StationDetailedInfo>
-
             ) : (
-              <div className="lg:p-[24px] flex flex-col gap-[8px] pt-0 p-[24px]">
-
+              <div className="flex flex-col gap-[8px] p-[24px] pt-0 lg:p-[24px]">
                 {suggestionStations.map((item, index) => (
-                  <SuggestionStationCard station={item} key={index}
+                  <SuggestionStationCard
+                    station={item}
+                    key={index}
                     countRecyclableBoxes={countRecyclableBoxes}
                     countPendingBoxes={countPendingBoxes}
                     formatPhoneNumber={formatPhoneNumber}
@@ -638,9 +708,9 @@ function Map() {
                     isLg={isLg}
                     markerRefs={markerRefs}
                     setPopupStation={setPopupStation}
-                  />))}
+                  />
+                ))}
               </div>
-
             )}
           </div>
         ) : (
@@ -648,7 +718,7 @@ function Map() {
         )}
 
         {/* 地圖 */}
-        <div className="lg:h-[700px] md:h-[calc(100vh-264.2px)] w-full relative z-0 h-[calc(100vh-408.2px)]">
+        <div className="relative z-0 h-[calc(100vh-408.2px)] w-full md:h-[calc(100vh-264.2px)] lg:h-[700px]">
           <MapContainer
             // className="relative z-0"
             center={[stations[0].latitude, stations[0].longitude]} // 預設第一個站點
@@ -675,11 +745,9 @@ function Map() {
                   },
                 }}
               >
-                {isLg ?
-
+                {isLg ? (
                   <Popup>
                     {popupStation ? (
-
                       <PopupCardLg
                         station={popupStation}
                         countRecyclableBoxes={countRecyclableBoxes}
@@ -688,29 +756,23 @@ function Map() {
                         setIsSideBar={setIsSideBar}
                         setClickedId={setClickedId}
                       ></PopupCardLg>
-
                     ) : (
                       <p>載入中...</p>
                     )}
                   </Popup>
-
-                  : <Popup>
-
+                ) : (
+                  <Popup>
                     {popupStation ? (
-
-                      <PopupCard station={popupStation}
+                      <PopupCard
+                        station={popupStation}
                         countRecyclableBoxes={countRecyclableBoxes}
-                        countPendingBoxes={countPendingBoxes}>
-                      </PopupCard>
-
+                        countPendingBoxes={countPendingBoxes}
+                      ></PopupCard>
                     ) : (
                       <p>載入中...</p>
                     )}
-
-                  </Popup>}
-
-
-
+                  </Popup>
+                )}
               </Marker>
             ))}
 
@@ -718,7 +780,7 @@ function Map() {
 
             {/* 側邊欄開關 */}
             <button
-              className="absolute left-[0px] top-[273px] z-[999999999] h-[72px] w-[40px] rounded-r-lg border-b border-e border-t bg-white lg:inline hidden"
+              className="absolute left-[0px] top-[273px] z-[999999999] hidden h-[72px] w-[40px] rounded-r-lg border-b border-e border-t bg-white lg:inline"
               onClick={() => setIsSideBar(!isSideBar)}
             >
               {isSideBar ? (

--- a/src/components/MapNav.jsx
+++ b/src/components/MapNav.jsx
@@ -1,14 +1,14 @@
-import { Link, NavLink } from "react-router-dom";
+import { Link } from "react-router-dom";
 import logo from "@/assets/logo.svg";
 import logoSm from "@/assets/logo-sm.svg";
 import search from "@/assets/search.svg";
 import place from "@/assets/place.svg";
-import MenuLogin from "./MenuLogin";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import NavMenu from "./NavMenu";
 
 const style = {
   container:
-    "container mx-auto px-5 flex flex-col items-center justify-between py-2 md:flex-row",
+    "container mx-auto px-5 flex flex-col items-center justify-between py-2 md:flex-row ",
   logoContainer:
     "flex w-full items-center justify-between px-5 pb-2 shadow-[0px_1px_1px_0px_rgba(0,0,0,0.1)] backdrop-blur-[5px] md:w-auto md:px-0 md:pb-0 md:shadow-none md:backdrop-blur-none",
   menu: "hidden cursor-pointer md:block lg:hidden",
@@ -32,13 +32,14 @@ const SuggestedTags = ({ filteredTags, handleSelect }) => {
         maxHeight: "150px",
         overflowY: "auto",
         scrollbarWidth: "none",
-      }} className="w-full bg-white p-0 m-0 rounded-b-xl drop-shadow-lg"
+      }}
+      className="m-0 w-full rounded-b-xl bg-white p-0 drop-shadow-lg"
     >
       {filteredTags.slice(0, 3).map((tag) => (
         <li
           key={tag}
           onClick={() => handleSelect(tag)}
-          className="p-[12px] bg-white hover:bg-main-100 text-[#6F6F6F] hover:text-black"
+          className="bg-white p-[12px] text-[#6F6F6F] hover:bg-main-100 hover:text-black"
           style={{
             cursor: "pointer",
           }}
@@ -48,14 +49,19 @@ const SuggestedTags = ({ filteredTags, handleSelect }) => {
         </li>
       ))}
     </ul>
-  )
-}
+  );
+};
 
-function MapNav({ handleLocateUser, searchKeyWords, setSearchKeyWords, handleSearchStations, availableTags,showSuggestedTags,setShowSuggestedTags }) {
-
-  const [filteredTags, setFilteredTags] = useState([]);//儲存被篩選出的tags
-  
-
+function MapNav({
+  handleLocateUser,
+  searchKeyWords,
+  setSearchKeyWords,
+  handleSearchStations,
+  availableTags,
+  showSuggestedTags,
+  setShowSuggestedTags,
+}) {
+  const [filteredTags, setFilteredTags] = useState([]); //儲存被篩選出的tags
 
   const handleChange = (event) => {
     const value = event.target.value;
@@ -65,8 +71,8 @@ function MapNav({ handleLocateUser, searchKeyWords, setSearchKeyWords, handleSea
       // 過濾符合的選項
       setFilteredTags(
         availableTags.filter((tag) =>
-          tag.toLowerCase().includes(value.toLowerCase())
-        )
+          tag.toLowerCase().includes(value.toLowerCase()),
+        ),
       );
 
       setShowSuggestedTags(true);
@@ -80,7 +86,6 @@ function MapNav({ handleLocateUser, searchKeyWords, setSearchKeyWords, handleSea
     setSearchKeyWords(tag);
     setShowSuggestedTags(false);
   };
-
 
   return (
     <div className="relative">
@@ -100,31 +105,46 @@ function MapNav({ handleLocateUser, searchKeyWords, setSearchKeyWords, handleSea
               </picture>
             </Link>
             <div className="md:hidden">
-              <MenuLogin />
+              <NavMenu />
             </div>
           </div>
           <div className={style.formContainer}>
-            <form className={style.form} onSubmit={(e) => handleSearchStations(e)}>
-              <input className={style.input} placeholder="輸入地標 或 街道名稱" value={searchKeyWords} onChange={(e) => handleChange(e)} />
+            <form
+              className={style.form}
+              onSubmit={(e) => handleSearchStations(e)}
+            >
+              <input
+                className={style.input}
+                placeholder="輸入地標 或 街道名稱"
+                value={searchKeyWords}
+                onChange={(e) => handleChange(e)}
+              />
               <button type="submit">
                 <img src={search} alt="搜尋" className={style.searchIcons} />
               </button>
-{/* 搜尋建議 */}
-<div className="absolute z-[1000]  flex justify-center top-[135%] left-0 w-full">
-      {showSuggestedTags && filteredTags.length > 0 && (
-        <SuggestedTags filteredTags={filteredTags}
-          handleSelect={handleSelect}></SuggestedTags>)}
-      </div>
-
-
+              {/* 搜尋建議 */}
+              <div className="absolute left-0 top-[135%] z-[1000] flex w-full justify-center">
+                {showSuggestedTags && filteredTags.length > 0 && (
+                  <SuggestedTags
+                    filteredTags={filteredTags}
+                    handleSelect={handleSelect}
+                  ></SuggestedTags>
+                )}
+              </div>
             </form>
             <button className={style.placeBtn}>
               <img src={place} alt="place" className="max-w-max" />
-              <p className="fs-7 lg:fs-6" onClick={handleLocateUser}>定位</p>
+              <p className="fs-7 lg:fs-6" onClick={handleLocateUser}>
+                定位
+              </p>
             </button>
           </div>
-          <div className={style.menu}>
-            <MenuLogin />
+          <div className="hidden md:block">
+            <NavMenu />
+          </div>
+
+          {/* <div className={style.menu}>
+            <NavMenuSm />
           </div>
           <nav className={style.nav}>
             <NavLink
@@ -141,15 +161,10 @@ function MapNav({ handleLocateUser, searchKeyWords, setSearchKeyWords, handleSea
             >
               登入
             </NavLink>
-          </nav>
+          </nav> */}
         </div>
       </div>
-
-      
-
-
     </div>
-
   );
 }
 

--- a/src/components/MemberBanner.jsx
+++ b/src/components/MemberBanner.jsx
@@ -1,14 +1,17 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+
+import { useStation } from "@/hooks/useStation";
+import { useMember } from "@/hooks/useMember";
+
 import avatorLg from "@/assets/avator-lg.svg";
 import memberBannerBg01 from "@/assets/memberBanner-bg1.svg";
 import box from "@/assets/box.svg";
 import dialog from "@/assets/dialog.svg";
-import { FaStoreAlt } from "react-icons/fa";
-import { useLocation } from "react-router-dom";
-import { useStation } from "@/hooks/useStation";
+
 import Spinner from "./Spinner";
-import { useMember } from "@/hooks/useMember";
-import { useEffect, useState } from "react";
 import ErrorMessage from "./ErrorMessage";
+import Banner from "./BannerInfo";
 
 function MemberBanner() {
   const location = useLocation();
@@ -26,13 +29,15 @@ function MemberBanner() {
   const navType = getNavType();
 
   // 會員稱號
-  const { member, isLoadingMember, getMemberError } = useMember();
+  const { member, isLoadingMember, getMemberError, role } = useMember();
+  const { station, isLoadingStation } = useStation(10);
   const [transactionNums, setTransactionNums] = useState(0);
   useEffect(() => {
     if (member && member.user.user_metadata) {
       setTransactionNums(member.user.user_metadata.transaction_nums);
     }
   }, [member]);
+
   // 會員等級定義 => 轉運紙箱數為門檻
   // transactionNums > 0 => 相遇路人
   // transactionNums > 50 => 返箱青年
@@ -46,6 +51,7 @@ function MemberBanner() {
   };
   const [memberLevel, setMemberLevel] = useState(1);
   const [memberLevelTitle, setMemberLevelTitle] = useState("");
+
   useEffect(() => {
     if (transactionNums > 0 && transactionNums < 50) {
       setMemberLevel(1);
@@ -68,9 +74,6 @@ function MemberBanner() {
     transactionNums,
   ]);
 
-  if (isLoadingMember) return <Spinner />;
-  if (getMemberError) return <ErrorMessage errorMessage={member.message} />;
-
   return (
     <section className="bg-[#F3F3F3] bg-top bg-no-repeat md:bg-[url('@/assets/memberBanner-bg2.svg')]">
       <div className="container relative mx-auto flex flex-col items-center gap-10 py-20 text-center md:flex-row md:justify-between md:text-left">
@@ -82,7 +85,27 @@ function MemberBanner() {
             className="absolute -bottom-3 -left-14 hidden md:flex"
           />
         </div>
-        {navType === "normal" ? <NormalBanner /> : <AdminBanner />}
+        {navType === "normal" ? (
+          <Banner
+            title={member.user.user_metadata.display_name}
+            infoData={[
+              `會員編號：${member.user.id}`,
+              `電子信箱：${member.user.email}`,
+              `聯絡電話：${member.user.user_metadata.phone}`,
+            ]}
+            showApplyButton={role !== "storeOwner"}
+          />
+        ) : (
+          <Banner
+            title={station.station_name}
+            infoData={[
+              `站點編號：${station.id}`,
+              `地址：${station.address}`,
+              `聯絡電話：${station.phone}`,
+            ]}
+            showApplyButton={false}
+          />
+        )}
         <div className="relative h-60 w-80 md:w-[500px]">
           <h4 className="absolute left-12 top-6 z-30 rotate-6 text-nowrap text-center text-main-100 lg:left-48 lg:top-16">
             {navType === "normal" ? memberLevelTitle : "站長"}午安，
@@ -101,36 +124,3 @@ function MemberBanner() {
 }
 
 export default MemberBanner;
-
-function NormalBanner() {
-  return (
-    <div className="grow">
-      <h2 className="mb-4 text-black">Natasa</h2>
-      <div className="fs-6 mb-4 flex flex-col space-y-2 text-[#6F6F6F]">
-        <p>會員編號：Natasa1234</p>
-        <p>電子信箱：ntasa0101@gmail.com</p>
-        <p>連絡電話：0934134165</p>
-      </div>
-      <button className="btn flex items-center gap-1 text-main-200">
-        <FaStoreAlt className="text-white" />
-        申請成為轉運站站長
-      </button>
-    </div>
-  );
-}
-
-function AdminBanner() {
-  const { station, isLoadingStation } = useStation(10);
-  if (isLoadingStation) return <Spinner />;
-
-  return (
-    <div className="grow">
-      <h2 className="mb-4 text-black">{station.station_name}</h2>
-      <div className="fs-6 mb-4 flex flex-col space-y-2 text-[#6F6F6F]">
-        <p>站點編號：{station.id}</p>
-        <p>地址：{station.address}</p>
-        <p>連絡電話：{station.phone}</p>
-      </div>
-    </div>
-  );
-}

--- a/src/components/MemberInfo.jsx
+++ b/src/components/MemberInfo.jsx
@@ -1,14 +1,12 @@
+import { useEffect, useState } from "react";
+import { useMember } from "@/hooks/useMember";
+
 import village_master from "../assets/village_master.svg";
 import points_icon from "../assets/points.svg";
 import box_count from "../assets/box_count.svg";
 
 import ResponsiveSwiper from "./ui/ResponsiveSwiper";
 import MemberInfoForm from "./form/MemberInfoForm";
-
-import { useMember } from "@/hooks/useMember";
-import { useEffect, useState } from "react";
-import Spinner from "./Spinner";
-import ErrorMessage from "./ErrorMessage";
 
 const style = {
   cardContainer: "flex items-center justify-around rounded-2xl bg-white p-10",
@@ -18,17 +16,18 @@ const style = {
 
 function MemberInfo() {
   const { member, isLoadingMember, getMemberError } = useMember();
-  const [pointNum, setPointNum] = useState("");
-  const [transactionNums, setTransactionNums] = useState(0);
+  const pointNum = member.user.user_metadata.points;
+  const transactionNums = member.transactionsCounts;
 
-  console.log(member);
+  // const [pointNum, setPointNum] = useState("");
+  // const [transactionNums, setTransactionNums] = useState(0);
 
-  useEffect(() => {
-    if (member && member.user.user_metadata) {
-      setPointNum(member.user.user_metadata.points);
-      setTransactionNums(member.transactionsCounts);
-    }
-  }, [member]);
+  // useEffect(() => {
+  //   if (member && member.user.user_metadata) {
+  //     setPointNum(member.user.user_metadata.points);
+  //     setTransactionNums(member.transactionsCounts);
+  //   }
+  // }, [member]);
 
   // 會員等級定義 => 轉運紙箱數為門檻
   // transactionNums > 0 => 相遇路人
@@ -71,9 +70,6 @@ function MemberInfo() {
     memberTitle.level_4,
     transactionNums,
   ]);
-
-  if (isLoadingMember) return <Spinner />;
-  if (getMemberError) return <ErrorMessage errorMessage={member.message} />;
 
   return (
     <div className="w-full text-center">

--- a/src/components/MemberInfo.jsx
+++ b/src/components/MemberInfo.jsx
@@ -19,16 +19,6 @@ function MemberInfo() {
   const pointNum = member.user.user_metadata.points;
   const transactionNums = member.transactionsCounts;
 
-  // const [pointNum, setPointNum] = useState("");
-  // const [transactionNums, setTransactionNums] = useState(0);
-
-  // useEffect(() => {
-  //   if (member && member.user.user_metadata) {
-  //     setPointNum(member.user.user_metadata.points);
-  //     setTransactionNums(member.transactionsCounts);
-  //   }
-  // }, [member]);
-
   // 會員等級定義 => 轉運紙箱數為門檻
   // transactionNums > 0 => 相遇路人
   // transactionNums > 50 => 返箱青年

--- a/src/components/MemberInfo.jsx
+++ b/src/components/MemberInfo.jsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from "react";
 import { useMember } from "@/hooks/useMember";
 
 import village_master from "../assets/village_master.svg";
+import beginer from "../assets/beginer.svg";
+import young from "../assets/young.svg";
+import guardian from "../assets/guardian.svg";
 import points_icon from "../assets/points.svg";
 import box_count from "../assets/box_count.svg";
 
@@ -14,10 +17,14 @@ const style = {
   cardNumber: "text-6xl font-bold text-main-600",
 };
 
+const levelImages = [beginer, young, village_master, guardian];
+
 function MemberInfo() {
-  const { member, isLoadingMember, getMemberError } = useMember();
+  const { member } = useMember();
   const pointNum = member.user.user_metadata.points;
   const transactionNums = member.transactionsCounts;
+
+  console.log("MemberInfo", member);
 
   // 會員等級定義 => 轉運紙箱數為門檻
   // transactionNums > 0 => 相遇路人
@@ -30,31 +37,35 @@ function MemberInfo() {
     level_3: "箱村村長",
     level_4: "箱村守護者",
   };
+
   const [memberLevel, setMemberLevel] = useState(1);
   const [memberLevelTitle, setMemberLevelTitle] = useState("");
   const [levelUpNum, setLevelUpNum] = useState("");
   const [initialSlide, setInitialSlide] = useState(0);
+
   useEffect(() => {
     if (transactionNums > 0 && transactionNums < 50) {
       setMemberLevel(1);
-      setMemberLevelTitle(memberTitle.level_2);
+      setMemberLevelTitle(memberTitle.level_1);
       setLevelUpNum(50 - transactionNums);
       setInitialSlide(0);
     } else if (transactionNums >= 50 && transactionNums < 100) {
       setMemberLevel(2);
-      setMemberLevelTitle(memberTitle.level_3);
+      setMemberLevelTitle(memberTitle.level_2);
       setLevelUpNum(100 - transactionNums);
       setInitialSlide(1);
     } else if (transactionNums >= 100 && transactionNums < 200) {
       setMemberLevel(3);
-      setMemberLevelTitle(memberTitle.level_4);
+      setMemberLevelTitle(memberTitle.level_3);
       setLevelUpNum(200 - transactionNums);
       setInitialSlide(2);
     } else if (transactionNums > 200) {
       setMemberLevel(4);
+      setMemberLevelTitle(memberTitle.level_4);
       setInitialSlide(3);
     }
   }, [
+    memberTitle.level_1,
     memberTitle.level_2,
     memberTitle.level_3,
     memberTitle.level_4,
@@ -90,7 +101,7 @@ function MemberInfo() {
             {/* 1號 div - 永遠在最上方 */}
             <div className="flex items-end justify-between p-4">
               <p className="flex text-3xl font-bold text-main-600">會員資訊</p>
-              <img src={village_master} alt="" />
+              <img src={levelImages[memberLevel - 1]} alt={memberLevelTitle} />
             </div>
 
             {/* 2號 div - 手機版時在最下方 */}
@@ -116,7 +127,7 @@ function MemberInfo() {
 
           {/* 會員資訊表單 */}
           {/* 3號 div - 左側容器，手機版時在中間 */}
-          <MemberInfoForm data={member} />
+          <MemberInfoForm data={member} memberLevelTitle={memberLevelTitle} />
 
           {/* 會員資訊 */}
           {/* 2號 div 的手機版位置 */}

--- a/src/components/MemberNav.jsx
+++ b/src/components/MemberNav.jsx
@@ -1,3 +1,4 @@
+import { useMember } from "@/hooks/useMember";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
 
 const style = {
@@ -15,6 +16,7 @@ const style = {
 
 function MemberNav() {
   const location = useLocation();
+  const { role } = useMember();
 
   const getNavType = () => {
     if (location.pathname.startsWith("/member/normal")) {
@@ -41,14 +43,16 @@ function MemberNav() {
           >
             <p className="fs-4">會員頁面</p>
           </NavLink>
-          <NavLink
-            to="/member/admin"
-            className={({ isActive }) =>
-              isActive ? style.mainNavActive : style.mainNav
-            }
-          >
-            <p className="fs-4">管理者頁面</p>
-          </NavLink>
+          {role === "storeOwner" && (
+            <NavLink
+              to="/member/admin"
+              className={({ isActive }) =>
+                isActive ? style.mainNavActive : style.mainNav
+              }
+            >
+              <h4>管理者頁面</h4>
+            </NavLink>
+          )}
         </div>
       </nav>
       {navType === "normal" ? <NormalNav /> : <AdminNav />}

--- a/src/components/MenuLogin.jsx
+++ b/src/components/MenuLogin.jsx
@@ -1,51 +1,119 @@
+import { NavLink } from "react-router-dom";
+
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@radix-ui/react-dropdown-menu";
 import { MenuIcon } from "lucide-react";
-import { CiLogin } from "react-icons/ci";
+import { Button } from "./ui/button";
+
+import { CiLogin, CiLogout } from "react-icons/ci";
+import { FaUser } from "react-icons/fa";
 import { MdPlace } from "react-icons/md";
-import { NavLink } from "react-router-dom";
+
+import HeaderAvatar from "./HeaderAvatar";
+import { useSignOut } from "@/hooks/useSignOut";
 
 const style = {
   mapAfter:
-    "after:content text-main-500 after:absolute after:left-8 after:mt-1 after:w-[64px] after:border-b-2 after:border-main-500",
+    "after:content text-main-500 after:absolute after:left-7 after:bottom-0 after:mt-1 after:w-[64px] after:border-b-2 after:border-main-500",
 };
-function Menu() {
+function MenuLogin({ currentMember, setCurrentMember }) {
+  const { signOutAsync } = useSignOut();
   return (
-    <>
-      <DropdownMenu>
-        <DropdownMenuTrigger>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost">
           <MenuIcon className="text-[#4767A2]" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="mt-4 w-[375px] pr-4 sm:mr-14 lg:hidden">
-          <DropdownMenuItem>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="mt-2 w-56 text-[#6f6f6f] lg:hidden"
+        align="end"
+      >
+        {currentMember && (
+          <>
+            <DropdownMenuLabel className="p-3 text-sm">
+              <div className="flex items-center gap-2">
+                <div className="grow-0">
+                  <HeaderAvatar currentMember={currentMember} />
+                </div>
+
+                <div className="font-normal leading-[24px]">
+                  <p className="text-[#6f6f6f]">
+                    {currentMember?.user_metadata?.display_name}, 歡迎回箱
+                  </p>
+                  <p>{currentMember?.email}</p>
+                </div>
+              </div>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator className="border" />
+          </>
+        )}
+
+        <DropdownMenuGroup>
+          <DropdownMenuItem className="my-3 p-0">
             <NavLink
               to="/map"
               className={({ isActive }) =>
-                isActive ? style.mapAfter : "text-[#6F6F6F]"
+                `${isActive ? style.mapAfter : "text-[#6F6F6F]"} flex w-full items-center gap-2 px-2 py-3 hover:text-main-500`
               }
             >
-              <h6 className="fs-6 flex items-center gap-2 hover:text-main-500">
-                <MdPlace />
-                紙箱地圖
-              </h6>
+              <MdPlace />
+              紙箱地圖
             </NavLink>
           </DropdownMenuItem>
-          <DropdownMenuItem>
-            <NavLink to="/signin">
-              <h6 className="fs-6 flex items-center gap-2 text-[#6F6F6F] hover:text-main-500">
+          <DropdownMenuItem className="my-0 mb-3 p-0">
+            <NavLink
+              to="/member"
+              className={({ isActive }) =>
+                `${isActive ? style.mapAfter : "text-[#6F6F6F]"} flex w-full items-center gap-2 px-2 py-3 hover:text-main-500`
+              }
+            >
+              <FaUser />
+              會員資訊
+            </NavLink>
+          </DropdownMenuItem>
+          {currentMember && (
+            <DropdownMenuItem className="my-0 mb-3 p-0">
+              <Button
+                variant="ghost"
+                className="w-full justify-start px-2 py-5 hover:text-main-500"
+                onClick={async () => {
+                  await signOutAsync();
+                  setCurrentMember(null);
+                }}
+              >
+                <CiLogout />
+                登出
+              </Button>
+            </DropdownMenuItem>
+          )}
+
+          {!currentMember && (
+            <DropdownMenuItem className="my-0 mb-3 p-0">
+              <NavLink
+                to="/signin"
+                className={({ isActive }) =>
+                  `${isActive ? style.mapAfter : "text-[#6F6F6F]"} flex w-full items-center gap-2 px-2 py-3 hover:text-main-500`
+                }
+              >
                 <CiLogin />
                 登入
-              </h6>
-            </NavLink>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </>
+              </NavLink>
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
-export default Menu;
+export default MenuLogin;

--- a/src/components/NavMenu.jsx
+++ b/src/components/NavMenu.jsx
@@ -1,8 +1,7 @@
-import { useQueryClient } from "@tanstack/react-query";
-import NavMenuSm from "./NavMenuSm";
 import { useEffect, useState } from "react";
-import { NavLink } from "react-router-dom";
-import HeaderSignInMenu from "./HeaderSignInMenu";
+import { useQueryClient } from "@tanstack/react-query";
+
+import NavMenuSm from "./NavMenuSm";
 import NavMenuLg from "./NavMenuLg";
 
 function NavMenu() {

--- a/src/components/NavMenu.jsx
+++ b/src/components/NavMenu.jsx
@@ -1,0 +1,47 @@
+import { useQueryClient } from "@tanstack/react-query";
+import NavMenuSm from "./NavMenuSm";
+import { useEffect, useState } from "react";
+import { NavLink } from "react-router-dom";
+import HeaderSignInMenu from "./HeaderSignInMenu";
+import NavMenuLg from "./NavMenuLg";
+
+function NavMenu() {
+  const queryClient = useQueryClient();
+  const member = queryClient.getQueryData(["member"])?.user;
+  const [currentMember, setCurrentMember] = useState(null);
+  const [role, setRole] = useState("");
+  console.log("Header", currentMember);
+
+  useEffect(() => {
+    if (member) {
+      setCurrentMember(member);
+      const role = member.user_metadata.roles.includes("storeOwner")
+        ? "storeOwner"
+        : "normal";
+      setRole(role);
+    }
+  }, [member, setCurrentMember]);
+
+  return (
+    <>
+      {/* mobile */}
+      <div className="lg:hidden">
+        <NavMenuSm
+          currentMember={currentMember}
+          setCurrentMember={setCurrentMember}
+          role={role}
+          setRole={setRole}
+        />
+      </div>
+      {/* desktop */}
+      <NavMenuLg
+        currentMember={currentMember}
+        setCurrentMember={setCurrentMember}
+        role={role}
+        setRole={setRole}
+      />
+    </>
+  );
+}
+
+export default NavMenu;

--- a/src/components/NavMenu.jsx
+++ b/src/components/NavMenu.jsx
@@ -10,7 +10,6 @@ function NavMenu() {
   const member = queryClient.getQueryData(["member"])?.user;
   const [currentMember, setCurrentMember] = useState(null);
   const [role, setRole] = useState("");
-  console.log("Header", currentMember);
 
   useEffect(() => {
     if (member) {

--- a/src/components/NavMenuLg.jsx
+++ b/src/components/NavMenuLg.jsx
@@ -1,0 +1,40 @@
+import { NavLink } from "react-router-dom";
+import HeaderSignInMenu from "./HeaderSignInMenu";
+
+const style = {
+  nav: "hidden items-center justify-between gap-6 lg:flex text-nowrap",
+  mapAfter:
+    "after:content text-main-500 after:absolute after:mt-1 after:w-[64px] after:border-b-2 after:border-main-500",
+};
+function NavMenuLg({ currentMember, setCurrentMember, role, setRole }) {
+  return (
+    <nav className={style.nav}>
+      <NavLink
+        to="/map"
+        className={({ isActive }) => (isActive ? style.mapAfter : "")}
+      >
+        <h6 className="hover:text-main-500">紙箱地圖</h6>
+      </NavLink>
+      {!currentMember && (
+        <NavLink
+          to="/signin"
+          className={({ isActive }) =>
+            isActive ? "btn fs-6 bg-main-500 shadow-none" : "btn"
+          }
+        >
+          登入
+        </NavLink>
+      )}
+      {currentMember && (
+        <HeaderSignInMenu
+          currentMember={currentMember}
+          setCurrentMember={setCurrentMember}
+          role={role}
+          setRole={setRole}
+        />
+      )}
+    </nav>
+  );
+}
+
+export default NavMenuLg;

--- a/src/components/NavMenuSm.jsx
+++ b/src/components/NavMenuSm.jsx
@@ -18,20 +18,22 @@ import { CiLogin, CiLogout } from "react-icons/ci";
 import { FaUser } from "react-icons/fa";
 import { MdPlace } from "react-icons/md";
 
-import HeaderAvatar from "./HeaderAvatar";
 import { useSignOut } from "@/hooks/useSignOut";
+
+import HeaderAvatar from "./HeaderAvatar";
 
 const style = {
   mapAfter:
     "after:content text-main-500 after:absolute after:left-7 after:bottom-0 after:mt-1 after:w-[64px] after:border-b-2 after:border-main-500",
 };
-function MenuLogin({ currentMember, setCurrentMember }) {
+
+function NavMenuSm({ currentMember, setCurrentMember, role, setRole }) {
   const { signOutAsync } = useSignOut();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost">
-          <MenuIcon className="text-[#4767A2]" />
+        <Button variant="ghost" className="[&_svg]:size-5">
+          <MenuIcon className="flex-1 shrink-0 text-[#4767A2]" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -70,17 +72,19 @@ function MenuLogin({ currentMember, setCurrentMember }) {
               紙箱地圖
             </NavLink>
           </DropdownMenuItem>
-          <DropdownMenuItem className="my-0 mb-3 p-0">
-            <NavLink
-              to="/member"
-              className={({ isActive }) =>
-                `${isActive ? style.mapAfter : "text-[#6F6F6F]"} flex w-full items-center gap-2 px-2 py-3 hover:text-main-500`
-              }
-            >
-              <FaUser />
-              會員資訊
-            </NavLink>
-          </DropdownMenuItem>
+          {currentMember && (
+            <DropdownMenuItem className="my-0 mb-3 p-0">
+              <NavLink
+                to="/member"
+                className={({ isActive }) =>
+                  `${isActive ? style.mapAfter : "text-[#6F6F6F]"} flex w-full items-center gap-2 px-2 py-3 hover:text-main-500`
+                }
+              >
+                <FaUser />
+                {role === "storeOwner" ? "會員資訊 & 站點管理" : "會員資訊"}
+              </NavLink>
+            </DropdownMenuItem>
+          )}
           {currentMember && (
             <DropdownMenuItem className="my-0 mb-3 p-0">
               <Button
@@ -89,6 +93,7 @@ function MenuLogin({ currentMember, setCurrentMember }) {
                 onClick={async () => {
                   await signOutAsync();
                   setCurrentMember(null);
+                  setRole("");
                 }}
               >
                 <CiLogout />
@@ -116,4 +121,4 @@ function MenuLogin({ currentMember, setCurrentMember }) {
   );
 }
 
-export default MenuLogin;
+export default NavMenuSm;

--- a/src/components/NormalDashboard.jsx
+++ b/src/components/NormalDashboard.jsx
@@ -1,0 +1,38 @@
+import { Outlet } from "react-router-dom";
+
+import Banner from "./Banner";
+import DashboardSubNav from "./DashboardSubNav";
+import DashboardNav from "./DashboardNav";
+import BannerInfo from "./BannerInfo";
+import BannerImage from "./BannerImage";
+
+function NormalDashboard({ member }) {
+  return (
+    <>
+      <Banner member={member}>
+        <BannerInfo
+          title={member.user.user_metadata.display_name}
+          infoData={[
+            `會員編號：${member.user.id}`,
+            `電子信箱：${member.user.email}`,
+            `聯絡電話：${member.user.user_metadata.phone}`,
+          ]}
+          showApplyButton={true}
+        />
+        <BannerImage
+          role="normal"
+          transactionNums={member.transactionsCounts}
+        />
+      </Banner>
+      <main>
+        <DashboardNav role="normal" />
+        <DashboardSubNav role="normal" />
+        <section className="container mx-auto my-10">
+          <Outlet />
+        </section>
+      </main>
+    </>
+  );
+}
+
+export default NormalDashboard;

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,23 @@
+import { useMember } from "@/hooks/useMember";
+import { useEffect } from "react";
+import { Outlet, useNavigate } from "react-router-dom";
+import Spinner from "./Spinner";
+import ErrorMessage from "./ErrorMessage";
+
+function ProtectedRoute() {
+  const { isLoadingMember, isAuthenticated, getMemberError } = useMember();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLoadingMember && !isAuthenticated && !getMemberError)
+      navigate("/signin");
+  }, [isLoadingMember, isAuthenticated, getMemberError, navigate]);
+
+  if (isLoadingMember) return <Spinner />;
+  if (getMemberError)
+    return <ErrorMessage errorMessage={getMemberError.message} />;
+
+  if (isAuthenticated) return <Outlet />;
+}
+
+export default ProtectedRoute;

--- a/src/components/UpdateUserImage.jsx
+++ b/src/components/UpdateUserImage.jsx
@@ -1,0 +1,88 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { useUpdateMember } from "@/hooks/useUpdateMember";
+import { apiUploadImage } from "@/services/apiAuth";
+
+const FormSchema = z.object({
+  avatar: z.instanceof(FileList).optional(),
+  avatar_url: z.string(), // 確保 username 有值
+});
+
+function UpdateUserImage() {
+  const { updateMember, updateMemberError, isUpdating } = useUpdateMember();
+
+  const form = useForm({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      avatar: "",
+      avatar_url:
+        "https://zmxloeyrugpwhymnzped.supabase.co/storage/v1/object/public/avatars//my-notion-face-portrait.jpg",
+    },
+  });
+
+  async function onSubmit(data) {
+    console.log(data);
+    const res = await apiUploadImage(
+      "box-images",
+      data.avatar[0],
+      "8b9acdef-b856-4c78-ac16-36d199737957",
+    );
+    console.log("res", res);
+
+    // updateMember({
+    //   data: {
+    //     avatar_url: data.avatar_url,
+    //   },
+    // });
+  }
+
+  const avatarRef = form.register("avatar");
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="w-2/3 space-y-6">
+        <FormField
+          control={form.control}
+          name="avatar"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Avatar</FormLabel>
+              <FormControl>
+                <Input type="file" {...avatarRef} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="avatar_url"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>avatar_url</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">Submit</Button>
+      </form>
+    </Form>
+  );
+}
+export default UpdateUserImage;

--- a/src/components/form/AdminInfoForm.jsx
+++ b/src/components/form/AdminInfoForm.jsx
@@ -1,11 +1,12 @@
 import { useForm } from "react-hook-form";
 import { useState } from "react";
 import toast from "react-hot-toast";
-import { zodResolver } from "@hookform/resolvers/zod";
+
 import * as z from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 import { FaPen, FaTimes } from "react-icons/fa";
-// import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
+import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
 
 const formSchema = z.object({
   station_name: z.string().nonempty("站點名稱不得為空"),
@@ -20,7 +21,6 @@ const formSchema = z.object({
     }),
   ),
 });
-import { useUpdateStationInfo } from "@/hooks/useUpdateStationInfo";
 
 import PropTypes from "prop-types";
 AdminInfoForm.propTypes = { station: PropTypes.object };
@@ -62,7 +62,6 @@ function AdminInfoForm({ station }) {
 
   function onSubmit(values) {
     try {
-      console.log(values);
       updateStation({ ...values, id: station.id });
       setIsEditing(false);
     } catch (error) {

--- a/src/components/form/MemberInfoForm.jsx
+++ b/src/components/form/MemberInfoForm.jsx
@@ -18,34 +18,42 @@ import { Input } from "@/components/ui/input";
 import { FaPen } from "react-icons/fa";
 import { MdClose } from "react-icons/md";
 import { useUpdateMember } from "@/hooks/useUpdateMember";
+import { useQueryClient } from "@tanstack/react-query";
 
 // zod驗證規則
 const formSchema = z.object({
-  name: z.string().min(2, "姓名至少需要 2 個字"),
+  display_name: z.string().min(2, "姓名至少需要 2 個字"),
   phone: z.string().regex(/^09\d{8}$/, "請輸入正確的台灣手機號碼"),
+  avatar: z.instanceof(FileList).optional(),
 });
 
 function MemberInfoForm({ data }) {
   const [isEditing, setIsEditing] = useState(false);
-
-  // const { updateMember, updateMemberError, isUpdating } = useUpdateMember();
-
-  useEffect(() => {}, [data]);
+  const { updateMember, updateMemberError, isUpdating } = useUpdateMember();
 
   const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      name: data.user.user_metadata.display_name,
+      display_name: data.user.user_metadata.display_name,
       phone: data.user.user_metadata.phone.toString().replace("+886", "0"),
+      // avatar: new File(),
     },
   });
-  const { reset, formState } = form;
-  const { isSubmitSuccessful } = formState;
+  const { reset } = form;
+
+  const avatarRef = form.register("avatar");
 
   // 串接API後繼續完成
-  const onSubmit = (data) => {
-    console.log(data);
+  const onSubmit = (values) => {
+    const { display_name, phone } = values;
+    const avatar = values.avatar[0];
+    const newInfoObj = {
+      display_name,
+      phone,
+    };
     setIsEditing(false);
+    updateMember({ newInfoObj, avatar, userId: data.user.id });
+
     reset();
   };
 
@@ -68,7 +76,7 @@ function MemberInfoForm({ data }) {
         <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
           <FormField
             control={form.control}
-            name="name"
+            name="display_name"
             render={({ field }) => (
               <FormItem className="mb-6">
                 <FormLabel className="block text-start text-gray-700">
@@ -76,7 +84,7 @@ function MemberInfoForm({ data }) {
                 </FormLabel>
                 <FormControl>
                   <Input
-                    placeholder="請輸入會員名稱"
+                    placeholder="請輸入姓名"
                     type="text"
                     {...field}
                     className="bg-white py-4 focus-visible:border-none focus-visible:ring-main-500"
@@ -93,11 +101,11 @@ function MemberInfoForm({ data }) {
             render={({ field }) => (
               <FormItem className="mb-6">
                 <FormLabel className="block text-start text-gray-700">
-                  連絡電話
+                  聯絡電話
                 </FormLabel>
                 <FormControl>
                   <Input
-                    placeholder="請輸入連絡電話"
+                    placeholder="請輸入聯絡電話"
                     type="tel"
                     {...field}
                     className="bg-white py-4 focus-visible:border-none focus-visible:ring-main-500"
@@ -111,25 +119,13 @@ function MemberInfoForm({ data }) {
           <FormField
             control={form.control}
             name="avatar"
-            render={({ field: { onChange, ...fieldProps } }) => (
+            render={({ field }) => (
               <FormItem className="mb-6 text-start">
                 <FormLabel className="block text-start text-gray-700">
                   上傳頭貼
                 </FormLabel>
                 <FormControl>
-                  <Input
-                    type="file"
-                    accept="image/*"
-                    onChange={(e) => {
-                      const file = e.target.files?.[0]; // 取得選擇的檔案
-                      if (file && file.size > 2 * 1024 * 1024) {
-                        alert("檔案大小不能超過 2MB");
-                      } else {
-                        onChange(file); // 更新表單的值
-                      }
-                    }}
-                    disabled={!isEditing}
-                  />
+                  <Input type="file" disabled={!isEditing} {...avatarRef} />
                 </FormControl>
                 <FormMessage className="block text-start" />
               </FormItem>

--- a/src/components/form/MemberInfoForm.jsx
+++ b/src/components/form/MemberInfoForm.jsx
@@ -27,7 +27,7 @@ const formSchema = z.object({
   avatar: z.instanceof(FileList).optional(),
 });
 
-function MemberInfoForm({ data }) {
+function MemberInfoForm({ data, memberLevelTitle }) {
   const [isEditing, setIsEditing] = useState(false);
   const { updateMember, updateMemberError, isUpdating } = useUpdateMember();
 
@@ -36,10 +36,8 @@ function MemberInfoForm({ data }) {
     defaultValues: {
       display_name: data.user.user_metadata.display_name,
       phone: data.user.user_metadata.phone.toString().replace("+886", "0"),
-      // avatar: new File(),
     },
   });
-  const { reset } = form;
 
   const avatarRef = form.register("avatar");
 
@@ -53,14 +51,12 @@ function MemberInfoForm({ data }) {
     };
     setIsEditing(false);
     updateMember({ newInfoObj, avatar, userId: data.user.id });
-
-    reset();
   };
 
   return (
     <div className="order-2 rounded-3xl bg-white p-10 md:order-1 md:w-1/2">
       <div className="mb-6 flex items-center justify-between">
-        <p className="text-2xl font-bold text-gray-700">箱村村長</p>
+        <p className="text-2xl font-bold text-gray-700">{memberLevelTitle}</p>
         <div className="flex items-center justify-center">
           <button type="button" onClick={() => setIsEditing(!isEditing)}>
             {isEditing ? (

--- a/src/components/form/SigninForm.jsx
+++ b/src/components/form/SigninForm.jsx
@@ -16,22 +16,17 @@ import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 
 import { useSignIn } from "@/hooks/useSignIn";
+import { apiSignIn } from "@/services/apiAuth";
 
 // zod驗證規則
 const formSchema = z.object({
   email: z
     .string()
-    .nonempty("請填寫會員信箱")
+    .min(1, { message: "請填寫會員信箱" })
     .email("請輸入有效的電子信箱格式，例如：user@example.com"),
-  password: z
-    .string()
-    .nonempty("請填寫密碼")
-    .min(8, { message: "密碼長度至少為 8 個字元" }),
+  password: z.string().min(8, { message: "密碼長度至少為 8 個字元" }),
 });
 
-// storeOwner
-// test01@gmail.com
-// password1
 function SigninForm() {
   const form = useForm({
     resolver: zodResolver(formSchema),
@@ -43,19 +38,17 @@ function SigninForm() {
   const { reset } = form;
   const { signIn, isLoading } = useSignIn();
 
+  // { email: "test01@gmail.com", password: "password1" }
   // 表單提交
-  const onSubmit = (values) =>
-    signIn(values, {
+  function onSubmit(data) {
+    signIn(data, {
       onSettled: () => reset(),
     });
+  }
 
   return (
     <Form {...form}>
-      <form
-        onSubmit={form.handleSubmit(onSubmit)}
-        className="space-y-1.5"
-        noValidate
-      >
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-1.5">
         <FormField
           control={form.control}
           name="email"
@@ -66,8 +59,8 @@ function SigninForm() {
                 <Input
                   placeholder="請輸入電子信箱"
                   type="email"
-                  {...field}
                   className="bg-white focus-visible:border-none focus-visible:ring-main-500"
+                  {...field}
                 />
               </FormControl>
               <FormMessage />
@@ -84,8 +77,8 @@ function SigninForm() {
               <FormControl>
                 <PasswordInput
                   placeholder="請輸入密碼"
-                  {...field}
                   className="bg-white focus-visible:border-none focus-visible:ring-main-500"
+                  {...field}
                 />
               </FormControl>
               <FormMessage />

--- a/src/components/ui/avatar.jsx
+++ b/src/components/ui/avatar.jsx
@@ -1,0 +1,33 @@
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn("relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full", className)}
+    {...props} />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props} />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props} />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/src/hooks/useBoxTransactions.js
+++ b/src/hooks/useBoxTransactions.js
@@ -2,7 +2,7 @@ import {
   apiGetAdminTransactionRecords,
   apiGetMemberTransactionRecords,
 } from "@/services/apiBoxTransactions";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 /**
  * 自訂 Hook：使用 React Query 來取得 管理者-紙箱交易紀錄的交易資料
@@ -14,7 +14,11 @@ import { useQuery } from "@tanstack/react-query";
  *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
  *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
  */
-export function useAdminTransactionRecords(stationId) {
+export function useAdminTransactionRecords() {
+  const queryClient = useQueryClient();
+  const currentStation = queryClient.getQueryData(["stationAdmin"]);
+  const stationId = currentStation?.id;
+
   const {
     data: records,
     isLoading: isLoadingRecords,

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -22,7 +22,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
  */
 export function useBoxesForSelling() {
   const {
-    data: boxes = [], //若回傳null，表單搜尋功能會報錯
+    data: boxes = [], // 若回傳null，表單搜尋功能會報錯
     isLoading: isLoadingBoxes,
     error: boxesError,
   } = useQuery({
@@ -42,7 +42,11 @@ export function useBoxesForSelling() {
  *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
  *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
  */
-export function useBoxesForAdminManaging(stationId) {
+export function useBoxesForAdminManaging() {
+  const queryClient = useQueryClient();
+  const station = queryClient.getQueryData(["stationAdmin"]);
+  const stationId = station?.id;
+
   const {
     data: boxes,
     isLoading: isLoadingBoxes,
@@ -65,7 +69,11 @@ export function useBoxesForAdminManaging(stationId) {
  *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
  *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
  */
-export function useBoxesForScraping(stationId) {
+export function useBoxesForScraping() {
+  const queryClient = useQueryClient();
+  const station = queryClient.getQueryData(["stationAdmin"]);
+  const stationId = station?.id;
+
   const {
     data: boxes,
     isLoading: isLoadingBoxes,

--- a/src/hooks/useMember.js
+++ b/src/hooks/useMember.js
@@ -11,5 +11,11 @@ export function useMember() {
     queryFn: () => apiGetMember(),
   });
 
-  return { member, isLoadingMember, getMemberError };
+  return {
+    member,
+    isLoadingMember,
+    isAuthenticated: member?.user.role === "authenticated",
+    role: member?.user.user_metadata.roles.length > 1 ? "storeOwner" : "normal",
+    getMemberError,
+  };
 }

--- a/src/hooks/useMember.js
+++ b/src/hooks/useMember.js
@@ -9,7 +9,7 @@ export function useMember() {
   } = useQuery({
     queryKey: ["member"],
     queryFn: () => apiGetMember(),
-    staleTime: 1000 * 60 * 10, // ✅ 10 分鐘內不重新 fetch，減少不必要的渲染
+    // staleTime: 1000 * 60 * 10, // ✅ 10 分鐘內不重新 fetch，減少不必要的渲染
   });
 
   const roles = member?.user?.user_metadata?.roles || [];

--- a/src/hooks/useMember.js
+++ b/src/hooks/useMember.js
@@ -9,13 +9,16 @@ export function useMember() {
   } = useQuery({
     queryKey: ["member"],
     queryFn: () => apiGetMember(),
+    staleTime: 1000 * 60 * 10, // ✅ 10 分鐘內不重新 fetch，減少不必要的渲染
   });
+
+  const roles = member?.user?.user_metadata?.roles || [];
 
   return {
     member,
     isLoadingMember,
     isAuthenticated: member?.user.role === "authenticated",
-    role: member?.user.user_metadata.roles.length > 1 ? "storeOwner" : "normal",
+    role: roles.includes("storeOwner") ? "storeOwner" : "normal",
     getMemberError,
   };
 }

--- a/src/hooks/useSignIn.js
+++ b/src/hooks/useSignIn.js
@@ -11,14 +11,14 @@ export function useSignIn() {
   const { mutate: signIn, isPending: isLoading } = useMutation({
     mutationKey: ["signIn"],
     mutationFn: ({ email, password }) => apiSignIn({ email, password }),
-    onSuccess: (user) => {
+    onSuccess: (member) => {
       // 1. user 緩存資料
-      queryClient.setQueryData(["user"], user);
+      queryClient.setQueryData(["member"], member);
 
       // 2. token 存入 cookies
-      const { session } = user;
-      const expires = new Date(session.expires_at * 1000).toUTCString();
-      document.cookie = `accessToken=${session.access_token};expires=${expires}`;
+      // const { session } = member;
+      // const expires = new Date(session.expires_at * 1000).toUTCString();
+      // document.cookie = `accessToken=${session.access_token};expires=${expires}`;
 
       // 3. UI 提示訊息
       toast.success(`登入成功`);

--- a/src/hooks/useSignOut.js
+++ b/src/hooks/useSignOut.js
@@ -8,11 +8,16 @@ export function useSignOut() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
-  const { mutate: signOut, isPending: isLoading } = useMutation({
+  const {
+    mutate: signOut,
+    isPending: isLoading,
+    mutateAsync: signOutAsync,
+  } = useMutation({
     mutationKey: ["signOut"],
     mutationFn: apiSignOut,
     onSuccess: () => {
-      queryClient.setQueryData(['member'], null)
+      // queryClient.setQueryData(["member"], null);
+      queryClient.removeQueries();
       document.cookie = "accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC;";
       toast.success(`您已登出`);
 
@@ -25,5 +30,5 @@ export function useSignOut() {
     },
   });
 
-  return { signOut, isLoading };
+  return { signOut, isLoading, signOutAsync };
 }

--- a/src/hooks/useSignOut.js
+++ b/src/hooks/useSignOut.js
@@ -12,7 +12,7 @@ export function useSignOut() {
     mutationKey: ["signOut"],
     mutationFn: apiSignOut,
     onSuccess: () => {
-      queryClient.removeQueries({ queryKey: ["user"], exact: true });
+      queryClient.setQueryData(['member'], null)
       document.cookie = "accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC;";
       toast.success(`您已登出`);
 

--- a/src/hooks/useStation.js
+++ b/src/hooks/useStation.js
@@ -1,5 +1,5 @@
 import { apiGetStationById } from "@/services/apiStations";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 /**
  * 自訂 Hook：使用 React Query 來取得單一站點資料
@@ -26,7 +26,7 @@ export function useStation(clickedId) {
     error: stationError,
   } = useQuery({
     queryKey: ["station", stationId],
-    queryFn: () => apiGetStationById(stationId),
+    queryFn: () => apiGetStationById(stationId, "stationId"),
     enabled: !!stationId,
   });
 

--- a/src/hooks/useStationAdmin.js
+++ b/src/hooks/useStationAdmin.js
@@ -1,0 +1,23 @@
+import { apiGetStationById } from "@/services/apiStations";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+export function useStationAdmin() {
+  const queryClient = useQueryClient();
+  const {
+    user: { id: userId },
+  } = queryClient.getQueryData(["member"]);
+
+  console.log(userId);
+
+  const {
+    data: station,
+    isLoading: isLoadingStation,
+    error: stationError,
+  } = useQuery({
+    queryKey: ["stationAdmin", userId],
+    queryFn: () => apiGetStationById(userId, "userId"),
+    enabled: !!userId,
+  });
+
+  return { station, isLoadingStation, stationError };
+}

--- a/src/hooks/useStationAdmin.js
+++ b/src/hooks/useStationAdmin.js
@@ -3,18 +3,16 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 export function useStationAdmin() {
   const queryClient = useQueryClient();
-  const {
-    user: { id: userId },
-  } = queryClient.getQueryData(["member"]);
+  const member = queryClient.getQueryData(["member"]);
 
-  console.log(userId);
+  const userId = member?.user?.id;
 
   const {
     data: station,
     isLoading: isLoadingStation,
     error: stationError,
   } = useQuery({
-    queryKey: ["stationAdmin", userId],
+    queryKey: ["stationAdmin"],
     queryFn: () => apiGetStationById(userId, "userId"),
     enabled: !!userId,
   });

--- a/src/hooks/useUpdateAvailableSlots.js
+++ b/src/hooks/useUpdateAvailableSlots.js
@@ -10,7 +10,9 @@ export function useUpdateAvailableSlots() {
     mutationFn: apiUpdateAvailableSlots,
     onSuccess: (station) => {
       toast.success(`成功更新「可回收紙箱數量」`);
-      queryClient.invalidateQueries({ queryKey: ["station", station.id] });
+      queryClient.invalidateQueries({
+        queryKey: ["stationAdmin", station.user_id],
+      });
     },
     onError: () => {
       toast.error(`更新「可回收紙箱數量」失敗`);

--- a/src/hooks/useUpdateAvailableSlots.js
+++ b/src/hooks/useUpdateAvailableSlots.js
@@ -8,10 +8,10 @@ export function useUpdateAvailableSlots() {
   const { mutate: updateAvailableSlots, isPending: isLoading } = useMutation({
     mutationKey: ["updateAvailableSlots"],
     mutationFn: apiUpdateAvailableSlots,
-    onSuccess: (station) => {
+    onSuccess: () => {
       toast.success(`成功更新「可回收紙箱數量」`);
       queryClient.invalidateQueries({
-        queryKey: ["stationAdmin", station.user_id],
+        queryKey: ["stationAdmin"],
       });
     },
     onError: () => {

--- a/src/hooks/useUpdateStationInfo.js
+++ b/src/hooks/useUpdateStationInfo.js
@@ -15,10 +15,10 @@ export function useUpdateStationInfo() {
     onError: (err) => {
       toast.error(err.message);
     },
-    onSuccess: (station) => {
+    onSuccess: () => {
       toast.success("更新成功");
       queryClient.invalidateQueries({
-        queryKey: ["stationAdmin", station.user_id],
+        queryKey: ["stationAdmin"],
       });
     },
   });

--- a/src/hooks/useUpdateStationInfo.js
+++ b/src/hooks/useUpdateStationInfo.js
@@ -15,11 +15,13 @@ export function useUpdateStationInfo() {
     onError: (err) => {
       toast.error(err.message);
     },
-    onSuccess: (data) => {
+    onSuccess: (station) => {
       toast.success("更新成功");
-      queryClient.invalidateQueries({ queryKey: ["station", data.id] });
+      queryClient.invalidateQueries({
+        queryKey: ["stationAdmin", station.user_id],
+      });
     },
   });
 
-  return {  updateStation, updatedError, isUpdating };
+  return { updateStation, updatedError, isUpdating };
 }

--- a/src/pages/Member.jsx
+++ b/src/pages/Member.jsx
@@ -1,15 +1,18 @@
-import Header from "@/components/Header";
-import MemberBanner from "@/components/MemberBanner";
-import Footer from "@/components/Footer";
+import { useMember } from "@/hooks/useMember";
 
-import MemberNav from "@/components/MemberNav";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import NormalDashboard from "@/components/NormalDashboard";
+import AdminDashboard from "@/components/AdminDashboard";
 
 function Member() {
+  const { role, member } = useMember();
+  console.log(role);
   return (
     <>
       <Header />
-      <MemberBanner />
-      <MemberNav />
+      {role === "normal" && <NormalDashboard member={member} />}
+      {role === "storeOwner" && <AdminDashboard member={member} />}
       <Footer />
     </>
   );

--- a/src/pages/Member.jsx
+++ b/src/pages/Member.jsx
@@ -7,7 +7,6 @@ import AdminDashboard from "@/components/AdminDashboard";
 
 function Member() {
   const { role, member } = useMember();
-  console.log(role);
   return (
     <>
       <Header />

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -1,5 +1,6 @@
 import { apiGetTransactionsCounts } from "./apiBoxTransactions";
 import supabase from "./supabase";
+
 export async function apiSignIn({ email, password }) {
   try {
     let { data, error } = await supabase.auth.signInWithPassword({
@@ -8,7 +9,7 @@ export async function apiSignIn({ email, password }) {
     });
 
     if (error) throw error;
-
+    console.log("signin");
     return data;
   } catch (error) {
     throw new Error(error.message);

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -1,6 +1,5 @@
 import { apiGetTransactionsCounts } from "./apiBoxTransactions";
 import supabase from "./supabase";
-const { VITE_SUPABASE_URL } = import.meta.env;
 export async function apiSignIn({ email, password }) {
   try {
     let { data, error } = await supabase.auth.signInWithPassword({
@@ -51,12 +50,24 @@ export async function apiSignOut() {
   }
 }
 
+// {
+//   email: "test01@gmail.com",
+//   password: "password1",
+// },
+
 export async function apiGetMember() {
   try {
     // 測試使用，先登入後取得資料。
-    const signInUser = { email: "test01@gmail.com", password: "password1" };
+    console.log("get member");
+    const signInUser = {
+      email: "test01@gmail.com",
+      password: "password1",
+    };
 
     await apiSignIn(signInUser);
+
+    const { data: session } = await supabase.auth.getSession();
+    if (!session.session) return null;
 
     const {
       data: { user },

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -1,6 +1,6 @@
 import { apiGetTransactionsCounts } from "./apiBoxTransactions";
 import supabase from "./supabase";
-
+const { VITE_SUPABASE_URL } = import.meta.env;
 export async function apiSignIn({ email, password }) {
   try {
     let { data, error } = await supabase.auth.signInWithPassword({
@@ -71,7 +71,7 @@ export async function apiGetMember() {
 }
 
 // update 物件格式：
-// const obj = {
+// {
 //   data: {
 //     avatar_url: "https://fakeimg.pl/200/",
 //     display_name: "王志豪",
@@ -83,6 +83,23 @@ export async function apiGetMember() {
 export async function apiUpdateMember(newInfoObj) {
   try {
     const { data, error } = await supabase.auth.updateUser(newInfoObj);
+
+    if (error) throw error;
+
+    return data;
+  } catch (error) {
+    throw new Error(error.message);
+  }
+}
+
+// https://zmxloeyrugpwhymnzped.supabase.co/storage/v1/object/public/avatars//my-notion-face-portrait.jpg
+
+export async function apiUploadImage(bucket, imageFile, userId) {
+  const fileName = `${Date.now()}-${imageFile.name}`.replaceAll("/", "");
+  try {
+    const { data, error } = await supabase.storage
+      .from(bucket)
+      .upload(`${userId}/${fileName}`, imageFile);
 
     if (error) throw error;
 

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -1,5 +1,6 @@
 import { apiGetTransactionsCounts } from "./apiBoxTransactions";
 import supabase from "./supabase";
+
 const { VITE_SUPABASE_URL } = import.meta.env;
 
 export async function apiSignIn({ email, password }) {
@@ -10,7 +11,7 @@ export async function apiSignIn({ email, password }) {
     });
 
     if (error) throw error;
-    console.log("signin");
+
     return data;
   } catch (error) {
     throw new Error(error.message);
@@ -52,30 +53,8 @@ export async function apiSignOut() {
   }
 }
 
-// {
-//   email: "test01@gmail.com",
-//   password: "password1",
-// },
-
-// {
-//   email: "customer1@gmail.com",
-//   password: "customerPassword1",
-// },
-
 export async function apiGetMember() {
   try {
-    // 測試使用，先登入後取得資料。
-    // const signInUser = {
-    //   email: "customer1@gmail.com",
-    //   password: "customerPassword1",
-    // };
-
-    const signInUser = {
-      email: "test01@gmail.com",
-      password: "password1",
-    };
-    await apiSignIn(signInUser);
-
     const { data: session } = await supabase.auth.getSession();
     if (!session.session) return null;
 
@@ -91,22 +70,10 @@ export async function apiGetMember() {
   }
 }
 
-// update 物件格式：
-// {
-//   data: {
-//     avatar_url: "https://fakeimg.pl/200/",
-//     display_name: "王志豪",
-//     phone: "+886956135395",
-//     points: 48,
-//     roles: ["users", "storeOwner"],
-//   },
-// };
 export async function apiUpdateMember({ newInfoObj, avatar, userId }) {
-  console.log(newInfoObj);
   let avatarPath;
   try {
     if (avatar) {
-      console.log(avatar);
       const { data, error } = await apiUploadImage("avatars", avatar, userId);
       if (error) throw error;
       avatarPath = `${VITE_SUPABASE_URL}/storage/v1/object/public/${data.fullPath}`;
@@ -123,18 +90,9 @@ export async function apiUpdateMember({ newInfoObj, avatar, userId }) {
     return data;
   } catch (error) {
     console.error(error);
+    throw new Error(error.message);
   }
-
-  // try {
-  //
-  //   if (error) throw error;
-  //   return data;
-  // } catch (error) {
-  //   throw new Error(error.message);
-  // }
 }
-
-// https://zmxloeyrugpwhymnzped.supabase.co/storage/v1/object/public/avatars//my-notion-face-portrait.jpg
 
 export async function apiUploadImage(bucket, imageFile, userId) {
   const fileName = `${Date.now()}-${imageFile.name}`.replaceAll("/", "");

--- a/src/services/apiAuth.js
+++ b/src/services/apiAuth.js
@@ -55,15 +55,23 @@ export async function apiSignOut() {
 //   password: "password1",
 // },
 
+// {
+//   email: "customer1@gmail.com",
+//   password: "customerPassword1",
+// },
+
 export async function apiGetMember() {
   try {
     // 測試使用，先登入後取得資料。
-    console.log("get member");
+    // const signInUser = {
+    //   email: "customer1@gmail.com",
+    //   password: "customerPassword1",
+    // };
+
     const signInUser = {
       email: "test01@gmail.com",
       password: "password1",
     };
-
     await apiSignIn(signInUser);
 
     const { data: session } = await supabase.auth.getSession();

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -45,9 +45,8 @@ export async function apiGetBoxesForAdminManaging(stationId) {
     let { data: boxes, error } = await supabase
       .from("boxes")
       .select("*")
-      .in("status", ["售出", "自用", "可認領"])
-      .eq("station_id", stationId)
-      .order("id", { ascending: true });
+      .in("status", ["自用", "可認領"])
+      .eq("station_id", stationId);
 
     if (error) throw error;
 

--- a/src/services/apiStations.js
+++ b/src/services/apiStations.js
@@ -12,9 +12,7 @@ import supabase from "./supabase";
  */
 export async function apiGetStations() {
   try {
-    let { data: stations, error } = await supabase
-      .from("stations")
-      .select(`*`);
+    let { data: stations, error } = await supabase.from("stations").select(`*`);
 
     if (error) throw error;
 
@@ -29,7 +27,9 @@ export async function apiGetStations() {
   }
 }
 
-export async function apiGetStationById(stationId) {
+export async function apiGetStationById(id, idName) {
+  const idColumn = idName === "stationId" ? "id" : "user_id";
+  console.log(idColumn);
   try {
     let { data: station, error } = await supabase
       .from("stations")
@@ -40,16 +40,38 @@ export async function apiGetStationById(stationId) {
         referencedTable: "station_daily_hours",
         ascending: true,
       })
-      .eq("id", stationId)
+      .eq(idColumn, id)
       .single();
     if (error) throw error;
 
     return station;
   } catch (error) {
     console.error(error);
-    throw new Error(`無法取得 Station - id: ${stationId}  資料，請稍後再試`);
+    throw new Error(`無法取得 Station - ${idColumn}: ${id}  資料，請稍後再試`);
   }
 }
+
+// export async function getStationByMemberId(memberId) {
+//   try {
+//     let { data: station, error } = await supabase
+//       .from("stations")
+//       .select(
+//         `*,station_daily_hours(id, is_business_day, open_time, close_time, day_of_week, updated_at)`,
+//       )
+//       .order("day_of_week", {
+//         referencedTable: "station_daily_hours",
+//         ascending: true,
+//       })
+//       .eq("user_id", memberId)
+//       .single();
+//     if (error) throw error;
+
+//     return station;
+//   } catch (error) {
+//     console.error(error);
+//     throw new Error(`無法取得 Station - id: ${stationId}  資料，請稍後再試`);
+//   }
+// }
 
 // StationInfo  更新站點資訊格式：
 // {

--- a/src/services/apiStations.js
+++ b/src/services/apiStations.js
@@ -148,10 +148,8 @@ export async function apiUpdateStationInfo({
     if (Array.isArray(station_daily_hours) && station_daily_hours.length > 0) {
       const { data, error } = await updateStationHours(station_daily_hours);
 
-      if (error) {
-        console.log(error);
-        throw error;
-      }
+      if (error) throw error;
+
       updatedHours = data;
     }
 

--- a/src/services/apiStations.js
+++ b/src/services/apiStations.js
@@ -29,7 +29,6 @@ export async function apiGetStations() {
 
 export async function apiGetStationById(id, idName) {
   const idColumn = idName === "stationId" ? "id" : "user_id";
-  console.log(idColumn);
   try {
     let { data: station, error } = await supabase
       .from("stations")

--- a/src/services/apiStations.js
+++ b/src/services/apiStations.js
@@ -78,28 +78,6 @@ export async function apiGetStationById(id, idName) {
   }
 }
 
-// export async function getStationByMemberId(memberId) {
-//   try {
-//     let { data: station, error } = await supabase
-//       .from("stations")
-//       .select(
-//         `*,station_daily_hours(id, is_business_day, open_time, close_time, day_of_week, updated_at)`,
-//       )
-//       .order("day_of_week", {
-//         referencedTable: "station_daily_hours",
-//         ascending: true,
-//       })
-//       .eq("user_id", memberId)
-//       .single();
-//     if (error) throw error;
-
-//     return station;
-//   } catch (error) {
-//     console.error(error);
-//     throw new Error(`無法取得 Station - id: ${stationId}  資料，請稍後再試`);
-//   }
-// }
-
 // StationInfo  更新站點資訊格式：
 // {
 //   id: 1,   // station id

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -37,3 +37,15 @@ export function isExpired(expirationDate) {
   const currentDate = new Date();
   return expDate <= currentDate;
 }
+
+export function getPendingBoxes(boxes = []) {
+  const countsObj = {};
+  for (const box of boxes) {
+    if (countsObj[box.size] === undefined) {
+      countsObj[box.size] = 1;
+    } else {
+      countsObj[box.size] += 1;
+    }
+  }
+  return countsObj;
+}


### PR DESCRIPTION
## **背景**
- **角色驗證已完成，確保不同身份的使用者只能存取對應頁面。**
- **共用元件拆分完成，提升程式碼可維護性。**
- **Header 權限切換已實作，登入 / 登出能即時更新 UI。**
- **會員 & 站點管理者 API 已修正，確保資訊正確讀取。**
- **會員資料編輯與圖片上傳功能完成。**
- **地圖與站點資訊優化，確保可認領紙箱資料正確顯示。**


## **🔍 主要變更**
### **1️⃣ 角色驗證與 Protected Route**
- **新增 `ProtectedRoute`**：負責驗證登入狀態，確保未登入用戶無法存取會員頁面。
- **新增 `AdminProtectedRoute`**：負責驗證 `storeOwner` 身份，防止一般會員進入管理後台。
- **修正登入 / 登出流程**
  - `apiGetMember`：新增 `getSession` 判斷，確保 `getUser` 運行時有有效 `session`。

---

### **2️⃣ 會員與管理者頁面邏輯調整**
- **會員資訊頁 (`MemberInfo.jsx`)**
  - 直接讀取遠端資料，移除內建 `state`。
  - 移除 `Spinner` & `ErrorMessage`，改為 `ProtectedRoute` 判斷。
 
- **會員頁 (`Member.jsx`)**
  - 加入角色驗證，確保會員 & 站點管理者可以存取對應頁面。
 
- **站點管理者 (`AdminInfo.jsx`)**
  - 透過 `useStationAdmin` 讀取站點資訊，改用 `userId` 查詢。
  - `useStation.js`：更新 `apiGetStationById` 的傳入參數，適應不同角色的查詢方式。

---

### **3️⃣ 共用元件拆分**
- **Dashboard 結構調整**
  - `AdminDashboard.jsx`：處理站點管理者後台頁面。
  - `NormalDashboard.jsx`：處理一般會員的資訊頁面。

- **Banner 相關調整**
  - `Banner.jsx`：抽離 `AdminDashboard` & `NormalDashboard` 共用的 Banner 元件。
  - `BannerImage.jsx`：處理 Banner 右方的紙箱圖片。
  - `BannerInfo.jsx`：處理 Banner 左方的基本資訊。

- **導覽列結構調整**
  - `DashboardNav.jsx`：站點管理者 & 會員共用的主要導覽列。
  - `DashboardSubNav.jsx`：站點管理者 & 會員共用的次導覽列。

---

### **4️⃣ Header 權限切換**
- **調整 `Header` 結構**
  - `NavMenu.jsx`：拆分導覽列邏輯，提升可讀性與維護性。
  - `NavMenuLg.jsx` & `NavMenuSm.jsx`：處理大螢幕與小螢幕的導覽列。

- **登入 / 登出權限驗證**
  - `HeaderSignInMenu.jsx`：根據 `member` 狀態動態顯示不同選單。
  - `MapNav.jsx`：調整為調用`NavMenu.jsx`，並於不同大小於不同位置顯示 `NavMenu.jsx`。

---

### **5️⃣ 修正 & 優化**
- **會員 & 站點管理者 API**
  - `apiStations.js`：修正 `apiGetStationById`，確保站點管理者能使用 `userId` 查詢站點資訊。
  - `useUpdateAvailableSlots.js` & `useUpdateStationInfo.js`：更新快取 `queryKey`，使用 `["stationAdmin"]` 作為鍵值。

- **站點 & 紙箱查詢**
  - `useBoxes.js`：修正 `useBoxesForAdminManaging`、`useBoxesForScraping`，改用站點管理者 `station.id` 查詢紙箱資訊。
  - `useBoxTransactions.js`：`useAdminTransactionRecords` 調整為讀取快取資料中的管理者站點 ID 。

- **地圖功能修正**
  - `Map.jsx` & `StationInfo.jsx`：改採用 `useStation` 回傳的 `station.boxes` 作為可認領紙箱資訊。
  - `helpers.js`：新增 `getPendingBoxes` 方法，計算不同大小的可認領紙箱數量。

---

### **6️⃣ 會員資料編輯與圖片上傳**
- **4-1 會員編輯頁面**
  - `MemberInfoForm.jsx` & `AdminInfoForm.jsx`：處理會員與站點管理者的資料編輯。
  
---

### **7️⃣ 其他調整**
- **調整後台 `Nav` 樣式**
  - `DashboardNav.jsx`：調整為 Ana PR#59 修改的樣式。

- 移除不必要的程式碼 (`useEffect`、`state`)，提升效能與可讀性。

---
### 測試方式：
1. 一般使用者
   - [x] 未登入 時直接訪問 /member，是否自動跳轉到/signin
   - [x] 登入後 訪問 /member，是否能正常載入

2. 站點管理者 
   - [x] 使用 一般會員 (normal) 登入，然後訪問 /member/admin，是否自動跳轉回 /member/normal/memberInfo
   - [x] 站點管理者 (storeOwner) 登入，然後訪問 /member/admin，是否正常進入後台頁面
  
3. Header 權限驗證
   - [x] 未登入 時， Header 顯示「登入」按鈕
   - [x] 登入 時， Header 顯示 avatar 、 會員資訊頁面連結、登出按鈕
   - [x] 點擊登出  Header 重新顯示「登入」按鈕，並重新導向首頁
  
4. Map 與站點資訊測試
   - [ ] 按照原流程使用 Map 與查看站點資訊，是否都能順利運行，並顯示正確資料

5. 4-1 會員編輯資料 & 圖片上傳
   - [x] 是否能單純修改姓名 或 電話
   - [x] 是否能成功上傳圖片，並即時更新 banner 、Header 的頭貼