### PR TITLE
Feature: 完成新增交易記錄串接（5-5、5-7）、交易記錄與積分記錄顯示（4-3、4-4、5-5）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-router-dom": "^7.1.3",
         "styled-components": "^6.1.15",
         "swiper": "^11.2.3",
+        "uuid": "^11.1.0",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -2970,14 +2971,14 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2988,7 +2989,7 @@
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -8585,6 +8586,18 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "6.0.10",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-router-dom": "^7.1.3",
     "styled-components": "^6.1.15",
     "swiper": "^11.2.3",
+    "uuid": "^11.1.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/src/components/AdminInfo.jsx
+++ b/src/components/AdminInfo.jsx
@@ -24,8 +24,8 @@ const totalBoxes = function (boxes) {
 };
 
 function AdminInfo() {
-  const { station, isLoadingStation } = useStationAdmin(10);
-  const { boxes, isLoadingBoxes } = useBoxesTotalForSelling(10);
+  const { station, isLoadingStation } = useStationAdmin();
+  const { boxes, isLoadingBoxes } = useBoxesTotalForSelling();
   if (isLoadingStation) return <Spinner />;
   if (isLoadingBoxes) return <Spinner />;
   const result = totalBoxes(boxes);

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -88,9 +88,10 @@ function AdminTrade() {
     });
 
     const transaction = {
-      transaction_type: "認領",
+      transaction_type: data.paymentMethod === "cash" ? "購買" : "兌換",
       cash_cost: data.paymentMethod === "cash" ? totalCash : 0,
       points_cost: data.paymentMethod === "points" ? totalCash : 0,
+      earned_points: 2 * boxesArr.length,
       boxes: boxesArr,
     };
 

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import * as z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -21,10 +21,6 @@ const formSchema = z.object({
 function AdminTrade() {
   const navigate = useNavigate();
   const { createTransactionAsync } = useCreateTransaction();
-  // 從 5-3 傳遞 station_id
-  // const location = useLocation();
-  // const { station_id } = location.state;
-  // console.log("5-7收到站點編號", station_id);
 
   const methods = useForm({
     resolver: zodResolver(formSchema),
@@ -75,8 +71,6 @@ function AdminTrade() {
   };
 
   const onSubmit = async (data) => {
-    console.log("提交的資料:", data);
-
     const boxesArr = data.selectedRows.map((box) => {
       return {
         size: box.size,

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -90,7 +90,7 @@ function AdminTrade() {
     const transaction = {
       transaction_type: data.paymentMethod === "cash" ? "購買" : "兌換",
       cash_cost: data.paymentMethod === "cash" ? totalCash : 0,
-      points_cost: data.paymentMethod === "points" ? totalCash : 0,
+      points_cost: data.paymentMethod === "points" ? totalPoints : 0,
       earned_points: 2 * boxesArr.length,
       boxes: boxesArr,
     };

--- a/src/components/AdminTrade.jsx
+++ b/src/components/AdminTrade.jsx
@@ -1,13 +1,15 @@
-import AdminTradeTable from "./table/AdminTradeTable";
+import { useState } from "react";
+import { Controller, FormProvider, useForm } from "react-hook-form";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import * as z from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-import { useState } from "react";
-import { Controller, FormProvider, useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import * as z from "zod";
-import { useLocation, useNavigate } from "react-router-dom";
 import { useUpdateMultipleBoxes } from "@/hooks/useBoxes";
+import AdminTradeTable from "./table/AdminTradeTable";
+import { useCreateTransaction } from "@/hooks/useCreateTransaction";
 
 // 驗證 schema
 const formSchema = z.object({
@@ -18,10 +20,12 @@ const formSchema = z.object({
 
 function AdminTrade() {
   const navigate = useNavigate();
+  const { createTransactionAsync } = useCreateTransaction();
   // 從 5-3 傳遞 station_id
-  const location = useLocation();
-  const { station_id } = location.state;
-  console.log("5-7收到站點編號", station_id);
+  // const location = useLocation();
+  // const { station_id } = location.state;
+  // console.log("5-7收到站點編號", station_id);
+
   const methods = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -70,9 +74,28 @@ function AdminTrade() {
     setValues({ status: "售出" });
   };
 
-  const onSubmit = (data) => {
+  const onSubmit = async (data) => {
     console.log("提交的資料:", data);
+
+    const boxesArr = data.selectedRows.map((box) => {
+      return {
+        size: box.size,
+        box_id: box.id,
+        condition: box.condition,
+        cash_value: box.cash_value,
+        point_value: box.point_value,
+      };
+    });
+
+    const transaction = {
+      transaction_type: "認領",
+      cash_cost: data.paymentMethod === "cash" ? totalCash : 0,
+      points_cost: data.paymentMethod === "points" ? totalCash : 0,
+      boxes: boxesArr,
+    };
+
     updateMultipleBoxes({ boxIds, values });
+    await createTransactionAsync({ transaction, memberId: data.userId });
     navigate("/member/admin/boxesTable"); // 轉向至 5-3
   };
 

--- a/src/components/MemberInfo.jsx
+++ b/src/components/MemberInfo.jsx
@@ -24,8 +24,6 @@ function MemberInfo() {
   const pointNum = member.user.user_metadata.points;
   const transactionNums = member.transactionsCounts;
 
-  console.log("MemberInfo", member);
-
   // 會員等級定義 => 轉運紙箱數為門檻
   // transactionNums > 0 => 箱遇路人
   // transactionNums > 50 => 返箱青年

--- a/src/components/NavMenu.jsx
+++ b/src/components/NavMenu.jsx
@@ -1,19 +1,19 @@
 import { useEffect, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 
 import NavMenuSm from "./NavMenuSm";
 import NavMenuLg from "./NavMenuLg";
+import { useMember } from "@/hooks/useMember";
 
 function NavMenu() {
-  const queryClient = useQueryClient();
-  const member = queryClient.getQueryData(["member"])?.user;
+  const { member } = useMember();
   const [currentMember, setCurrentMember] = useState(null);
   const [role, setRole] = useState("");
 
   useEffect(() => {
     if (member) {
-      setCurrentMember(member);
-      const role = member.user_metadata.roles.includes("storeOwner")
+      console.log(member);
+      setCurrentMember(member.user);
+      const role = member.user.user_metadata.roles.includes("storeOwner")
         ? "storeOwner"
         : "normal";
       setRole(role);

--- a/src/components/NavMenu.jsx
+++ b/src/components/NavMenu.jsx
@@ -11,7 +11,6 @@ function NavMenu() {
 
   useEffect(() => {
     if (member) {
-      console.log(member);
       setCurrentMember(member.user);
       const role = member.user.user_metadata.roles.includes("storeOwner")
         ? "storeOwner"

--- a/src/components/UpdateUserImage.jsx
+++ b/src/components/UpdateUserImage.jsx
@@ -33,13 +33,11 @@ function UpdateUserImage() {
   });
 
   async function onSubmit(data) {
-    console.log(data);
     const res = await apiUploadImage(
       "box-images",
       data.avatar[0],
       "8b9acdef-b856-4c78-ac16-36d199737957",
     );
-    console.log("res", res);
 
     // updateMember({
     //   data: {

--- a/src/components/form/AdminAddBoxes.jsx
+++ b/src/components/form/AdminAddBoxes.jsx
@@ -1,7 +1,7 @@
 import { getTimestamp } from "@/utils/helpers";
 import { useFieldArray, useForm } from "react-hook-form";
 import { useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { useAddMultipleBoxes } from "@/hooks/useBoxes";
@@ -56,10 +56,7 @@ const formSchema = z.object({
 
 function AdminAddBoxes() {
   const navigate = useNavigate();
-  // 從 5-3 傳遞 station_id
-  // const location = useLocation();
-  // const { station_id } = location.state;
-  // console.log("5-6收到站點編號", station_id);
+
   const { control, handleSubmit, register, watch, setValue, formState } =
     useForm({
       resolver: zodResolver(formSchema),
@@ -75,6 +72,7 @@ function AdminAddBoxes() {
     control,
     name: "boxes",
   });
+
   const watchBoxes = watch("boxes");
   // 監聽紙箱大小與保存等級變化，更新對應現金與對應積分
   useEffect(() => {
@@ -87,12 +85,21 @@ function AdminAddBoxes() {
       );
     });
   }, [watchBoxes, setValue]);
+
   // 計算積分總計
   const totalPoints = watchBoxes.reduce((sum, box) => sum + box.points, 0);
   // 新增多比紙箱資料
-  const { addMultipleBoxes, isAdding } = useAddMultipleBoxes();
+  const { addMultipleBoxesAsync, isAdding } = useAddMultipleBoxes();
   const { createTransactionAsync } = useCreateTransaction();
-  const onSubmit = (data) => {
+
+  const onSubmit = async (data) => {
+    // 新增紙箱資料
+    const formData = {
+      user_id: data.user_id,
+      boxes: data.boxes,
+    };
+
+    // 新增交易記錄
     const transactionBoxes = data.boxes.map((box) => ({
       size: box.size,
       condition: box.condition,
@@ -108,22 +115,9 @@ function AdminAddBoxes() {
       boxes: transactionBoxes,
     };
 
-    console.log(transaction);
-
-    const formData = {
-      // station_id,
-      user_id: data.user_id,
-      boxes: data.boxes,
-    };
-    try {
-      createTransactionAsync({ transaction, memberId: data.user_id });
-
-      // addMultipleBoxes(formData);
-      console.log(formData);
-      // navigate("/member/admin/boxesTable");
-    } catch (error) {
-      console.error("Form submission error", error);
-    }
+    await addMultipleBoxesAsync(formData);
+    await createTransactionAsync({ transaction, memberId: data.user_id });
+    navigate("/member/admin/boxesTable");
   };
 
   return (

--- a/src/components/form/AdminAddBoxes.jsx
+++ b/src/components/form/AdminAddBoxes.jsx
@@ -107,11 +107,16 @@ function AdminAddBoxes() {
       point_value: box.points,
     }));
 
+    const totalEarnedPoints = data.boxes.reduce(
+      (acc, cur) => acc + cur.points,
+      0,
+    );
+
     const transaction = {
       transaction_type: "回收",
       cash_cost: 0,
       points_cost: 0,
-      earned_points: 2 * transactionBoxes.length,
+      earned_points: totalEarnedPoints,
       boxes: transactionBoxes,
     };
 

--- a/src/components/form/AdminAddBoxes.jsx
+++ b/src/components/form/AdminAddBoxes.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { useAddMultipleBoxes } from "@/hooks/useBoxes";
+import { useCreateTransaction } from "@/hooks/useCreateTransaction";
 
 const sizeOptions = [
   { label: "特大", value: "特大", points: 5 },
@@ -56,9 +57,9 @@ const formSchema = z.object({
 function AdminAddBoxes() {
   const navigate = useNavigate();
   // 從 5-3 傳遞 station_id
-  const location = useLocation();
-  const { station_id } = location.state;
-  console.log("5-6收到站點編號", station_id);
+  // const location = useLocation();
+  // const { station_id } = location.state;
+  // console.log("5-6收到站點編號", station_id);
   const { control, handleSubmit, register, watch, setValue, formState } =
     useForm({
       resolver: zodResolver(formSchema),
@@ -90,16 +91,36 @@ function AdminAddBoxes() {
   const totalPoints = watchBoxes.reduce((sum, box) => sum + box.points, 0);
   // 新增多比紙箱資料
   const { addMultipleBoxes, isAdding } = useAddMultipleBoxes();
+  const { createTransactionAsync } = useCreateTransaction();
   const onSubmit = (data) => {
+    const transactionBoxes = data.boxes.map((box) => ({
+      size: box.size,
+      condition: box.condition,
+      cash_value: box.cash_value,
+      point_value: box.points,
+    }));
+
+    const transaction = {
+      transaction_type: "回收",
+      cash_cost: 0,
+      points_cost: 0,
+      earned_points: 2 * transactionBoxes.length,
+      boxes: transactionBoxes,
+    };
+
+    console.log(transaction);
+
     const formData = {
-      station_id,
+      // station_id,
       user_id: data.user_id,
       boxes: data.boxes,
     };
     try {
-      addMultipleBoxes(formData);
+      createTransactionAsync({ transaction, memberId: data.user_id });
+
+      // addMultipleBoxes(formData);
       console.log(formData);
-      navigate("/member/admin/boxesTable");
+      // navigate("/member/admin/boxesTable");
     } catch (error) {
       console.error("Form submission error", error);
     }

--- a/src/components/form/AdminInfoForm.jsx
+++ b/src/components/form/AdminInfoForm.jsx
@@ -39,7 +39,7 @@ function AdminInfoForm({ station }) {
   const [isEditing, setIsEditing] = useState(false);
   const { updateStation, isUpdating } = useUpdateStationInfo();
 
-  const { handleSubmit, register } = useForm({
+  const { handleSubmit, register, setValue } = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
       station_name: station.station_name || "",
@@ -69,11 +69,32 @@ function AdminInfoForm({ station }) {
     }
   }
 
+  function handleClickClose() {
+    setIsEditing(!isEditing);
+    setValue("station_name", station.station_name);
+    setValue("phone", station.phone);
+    setValue(
+      "station_daily_hours",
+      Array.from({ length: 7 }, (_, index) => {
+        const dayData = station.station_daily_hours.find(
+          (item) => item.day_of_week === index,
+        );
+
+        return {
+          id: dayData ? dayData.id : "",
+          open_time: dayData ? dayData.open_time.substring(0, 5) : "",
+          close_time: dayData ? dayData.close_time.substring(0, 5) : "",
+          is_business_day: dayData ? dayData.is_business_day : false,
+        };
+      }),
+    );
+  }
+
   return (
     <>
       <div className="flex items-center justify-between">
         <p className="text-2xl font-bold text-gray-700">轉運站長</p>
-        <button type="button" onClick={() => setIsEditing(!isEditing)}>
+        <button type="button" onClick={handleClickClose}>
           {isEditing ? (
             <FaTimes size={20} />
           ) : (

--- a/src/components/form/AdminRecyclingBoxForm.jsx
+++ b/src/components/form/AdminRecyclingBoxForm.jsx
@@ -22,7 +22,6 @@ function AdminRecyclingBoxForm({ station }) {
 
   function onSubmit(available_slots) {
     try {
-      console.log({ stationId: station.id, ...available_slots });
       updateAvailableSlots({ stationId: station.id, ...available_slots });
       toast.success("提交成功");
       setIsEditing(false);

--- a/src/components/form/MemberInfoForm.jsx
+++ b/src/components/form/MemberInfoForm.jsx
@@ -18,7 +18,6 @@ import { Input } from "@/components/ui/input";
 import { FaPen } from "react-icons/fa";
 import { MdClose } from "react-icons/md";
 import { useUpdateMember } from "@/hooks/useUpdateMember";
-import { useQueryClient } from "@tanstack/react-query";
 
 // zod驗證規則
 const formSchema = z.object({

--- a/src/components/form/MemberInfoForm.jsx
+++ b/src/components/form/MemberInfoForm.jsx
@@ -52,12 +52,21 @@ function MemberInfoForm({ data, memberLevelTitle }) {
     updateMember({ newInfoObj, avatar, userId: data.user.id });
   };
 
+  function handleClickClose() {
+    setIsEditing(!isEditing);
+    form.setValue("display_name", data.user.user_metadata.display_name);
+    form.setValue(
+      "phone",
+      data.user.user_metadata.phone.toString().replace("+886", "0"),
+    );
+  }
+
   return (
     <div className="order-2 rounded-3xl bg-white p-10 md:order-1 md:w-1/2">
       <div className="mb-6 flex items-center justify-between">
         <p className="text-2xl font-bold text-gray-700">{memberLevelTitle}</p>
         <div className="flex items-center justify-center">
-          <button type="button" onClick={() => setIsEditing(!isEditing)}>
+          <button type="button" onClick={handleClickClose}>
             {isEditing ? (
               <MdClose className="text-main-600" size={30} />
             ) : (

--- a/src/components/form/UpdateBoxForm.jsx
+++ b/src/components/form/UpdateBoxForm.jsx
@@ -74,7 +74,6 @@ export default function UpdateBoxForm({ row, setOpen }) {
         boxId: row.id,
         values: { ...formattedValues, image_url: imageUrl },
       });
-      console.log("更新成功", row.id, formattedValues);
       setOpen(false);
     } catch (error) {
       console.error("Form submission error", error);

--- a/src/components/form/UpdateBoxForm.jsx
+++ b/src/components/form/UpdateBoxForm.jsx
@@ -68,7 +68,6 @@ export default function UpdateBoxForm({ row, setOpen }) {
         );
         const { publicUrl } = await res;
         imageUrl = publicUrl;
-        console.log("res", res);
       }
       // 更新boxes資料
       await updateBox({

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -20,7 +20,7 @@ import { useNavigate } from "react-router-dom";
 const AdminBoxManageTable = () => {
   const navigate = useNavigate();
   // 取得可認領紙箱資料
-  const { boxes, isLoadingBoxes, boxesError } = useBoxesForAdminManaging(10);
+  const { boxes, isLoadingBoxes, boxesError } = useBoxesForAdminManaging();
 
   // 篩選搜尋資料
   const [originData, setOriginData] = useState([]);

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -16,6 +16,7 @@ import { FaRecycle } from "react-icons/fa";
 import UpdateBoxDialog from "../dialog/UpdateBoxDialog";
 import DeleteBoxDialog from "../dialog/DeleteBoxDialog";
 import { useNavigate } from "react-router-dom";
+import { formatUTCTimestamp } from "@/utils/helpers";
 
 const AdminBoxManageTable = () => {
   const navigate = useNavigate();
@@ -64,13 +65,13 @@ const AdminBoxManageTable = () => {
     },
     {
       name: "新增時間",
-      selector: (row) => row.created_at?.replace("T", " ").slice(0, 16),
+      selector: (row) => formatUTCTimestamp(row.created_at),
       sortable: true,
       width: "135px",
     },
     {
       name: "更新時間",
-      selector: (row) => row.updated_at?.replace("T", " ").slice(0, 16),
+      selector: (row) => formatUTCTimestamp(row.updated_at),
       sortable: true,
       width: "135px",
     },

--- a/src/components/table/AdminBoxManageTable.jsx
+++ b/src/components/table/AdminBoxManageTable.jsx
@@ -58,7 +58,7 @@ const AdminBoxManageTable = () => {
           <img
             src={row.image_url}
             alt="box-image"
-            className="h-[70px] w-[70px] transition-transform duration-300 hover:scale-150"
+            className="h-[70px] w-[70px] object-cover transition-transform duration-300 hover:scale-150"
           />
         </div>
       ),

--- a/src/components/table/AdminDeprecatedTable.jsx
+++ b/src/components/table/AdminDeprecatedTable.jsx
@@ -50,7 +50,7 @@ const AdminDeprecatedTable = () => {
           <img
             src={row.image_url}
             alt="box-image"
-            className="h-[70px] w-[70px] transition-transform duration-300 hover:scale-150"
+            className="h-[70px] w-[70px] object-cover transition-transform duration-300 hover:scale-150"
           />
         </div>
       ),

--- a/src/components/table/AdminTradeHistoryTable.jsx
+++ b/src/components/table/AdminTradeHistoryTable.jsx
@@ -8,6 +8,7 @@ import { customStyles, paginationComponentOptions } from "@/data/constants";
 import { useAdminTransactionRecords } from "@/hooks/useBoxTransactions";
 import Spinner from "../../components/Spinner";
 import ErrorMessage from "../../components/ErrorMessage";
+import { formatUTCTimestamp } from "@/utils/helpers";
 
 const AdminTradeHistoryTable = () => {
   // 取得可認領紙箱資料
@@ -16,8 +17,6 @@ const AdminTradeHistoryTable = () => {
 
   if (isLoadingRecords) return <Spinner />;
   if (recordsError) return <ErrorMessage errorMessage={recordsError.message} />;
-
-  console.log(records);
 
   const expendedData = records.flatMap((transaction) =>
     transaction.boxes.map((box) => ({
@@ -31,18 +30,16 @@ const AdminTradeHistoryTable = () => {
     })),
   );
 
-  console.log(expendedData);
-
   // 欄位
   const columns = [
     {
       name: "交易時間",
-      selector: (row) => row.created_at?.replace("T", " ").slice(0, 16),
+      selector: (row) => formatUTCTimestamp(row.created_at),
       sortable: true,
     },
     {
       name: "紙箱編號",
-      selector: (row) => row.box_id,
+      selector: (row) => row.box_id || `-`,
       sortable: true,
     },
     { name: "紙箱大小", selector: (row) => row.size, sortable: true },
@@ -71,7 +68,6 @@ const AdminTradeHistoryTable = () => {
           : "現金",
     },
   ];
-  const data = [...records];
 
   return (
     <>

--- a/src/components/table/AdminTradeHistoryTable.jsx
+++ b/src/components/table/AdminTradeHistoryTable.jsx
@@ -12,9 +12,27 @@ import ErrorMessage from "../../components/ErrorMessage";
 const AdminTradeHistoryTable = () => {
   // 取得可認領紙箱資料
   const { records, isLoadingRecords, recordsError } =
-    useAdminTransactionRecords(10);
+    useAdminTransactionRecords();
+
   if (isLoadingRecords) return <Spinner />;
   if (recordsError) return <ErrorMessage errorMessage={recordsError.message} />;
+
+  console.log(records);
+
+  const expendedData = records.flatMap((transaction) =>
+    transaction.boxes.map((box) => ({
+      created_at: transaction.created_at,
+      box_id: box.box_id,
+      size: box.size,
+      condition: box.condition,
+      user_id: transaction.user_id,
+      transaction_type: transaction.transaction_type,
+      user_name_snapshot: transaction.user_name_snapshot,
+    })),
+  );
+
+  console.log(expendedData);
+
   // 欄位
   const columns = [
     {
@@ -24,7 +42,7 @@ const AdminTradeHistoryTable = () => {
     },
     {
       name: "紙箱編號",
-      selector: (row) => row.id,
+      selector: (row) => row.box_id,
       sortable: true,
     },
     { name: "紙箱大小", selector: (row) => row.size, sortable: true },
@@ -33,9 +51,13 @@ const AdminTradeHistoryTable = () => {
       selector: (row) => row.condition,
       sortable: true,
     },
+    // {
+    //   name: "會員編號",
+    //   selector: (row) => row.user_id?.slice(0, 18),
+    // },
     {
-      name: "會員編號",
-      selector: (row) => row.user_id?.slice(0, 18),
+      name: "會員姓名",
+      selector: (row) => row?.user_name_snapshot,
     },
     {
       name: "交易方式",
@@ -57,7 +79,7 @@ const AdminTradeHistoryTable = () => {
       <StyleSheetManager shouldForwardProp={isPropValid}>
         <DataTable
           columns={columns}
-          data={data}
+          data={expendedData}
           pagination
           customStyles={customStyles}
           paginationComponentOptions={paginationComponentOptions}

--- a/src/components/table/MemberInfoHistoryTable.jsx
+++ b/src/components/table/MemberInfoHistoryTable.jsx
@@ -20,7 +20,9 @@ const MemberInfoHistoryTable = () => {
       station_name_snapshot: transaction.station_name_snapshot,
       transaction_type: transaction.transaction_type,
       points_cost: transaction.points_cost,
-      earned_points: transaction.earned_points / transaction.boxes.length,
+      earned_points: box.point_value,
+      total_earned_points: transaction.earned_points,
+      boxes_counts: transaction.boxes.length,
     })),
   );
 
@@ -48,29 +50,12 @@ const MemberInfoHistoryTable = () => {
     },
     {
       name: "換算積分",
-      selector: (row) => {
-        if (
-          row.transaction_type === "回收" ||
-          row.transaction_type === "購買"
-        ) {
-          return `+${row.earned_points}`;
-        } else {
-          return row.earned_points - row.points_cost > 0
-            ? `+${row.earned_points - row.points_cost}`
-            : `${row.earned_points - row.points_cost}`;
-        }
-      },
-      // cell: (row) => (
-      //   <span
-      //     style={{
-      //       color: row.earned_points - row.points_cost > 0 ? "green" : "red",
-      //     }}
-      //   >
-      //     {row.earned_points - row.points_cost > 0
-      //       ? `+${row.earned_points - row.points_cost}`
-      //       : `${row.earned_points - row.points_cost}`}
-      //   </span>
-      // ),
+      selector: (row) =>
+        row.transaction_type === "回收"
+          ? `+${row.earned_points}`
+          : row.transaction_type === "購買"
+            ? `+${row.total_earned_points / row.boxes_counts}`
+            : `${row.total_earned_points - row.points_cost}`,
     },
   ];
 

--- a/src/components/table/MemberInfoHistoryTable.jsx
+++ b/src/components/table/MemberInfoHistoryTable.jsx
@@ -8,7 +8,7 @@ import ErrorMessage from "../ErrorMessage";
 const MemberInfoHistoryTable = () => {
   const { records, isLoadingRecords, recordsError } =
     useMemberTransactionRecords();
-  console.log(records);
+
   if (isLoadingRecords) return <Spinner />;
   if (recordsError) return <ErrorMessage errorMessage={recordsError.message} />;
 

--- a/src/components/table/MemberInfoHistoryTable.jsx
+++ b/src/components/table/MemberInfoHistoryTable.jsx
@@ -6,6 +6,24 @@ import Spinner from "../Spinner";
 import ErrorMessage from "../ErrorMessage";
 
 const MemberInfoHistoryTable = () => {
+  const { records, isLoadingRecords, recordsError } =
+    useMemberTransactionRecords();
+  console.log(records);
+  if (isLoadingRecords) return <Spinner />;
+  if (recordsError) return <ErrorMessage errorMessage={recordsError.message} />;
+
+  const expendedData = records.flatMap((transaction) =>
+    transaction.boxes.map((box) => ({
+      created_at: transaction.created_at,
+      size: box.size,
+      condition: box.condition,
+      station_name_snapshot: transaction.station_name_snapshot,
+      transaction_type: transaction.transaction_type,
+      points_cost: transaction.points_cost,
+      earned_points: transaction.earned_points / transaction.boxes.length,
+    })),
+  );
+
   // 欄位
   const columns = [
     {
@@ -35,22 +53,31 @@ const MemberInfoHistoryTable = () => {
           row.transaction_type === "回收" ||
           row.transaction_type === "購買"
         ) {
-          return "+" + row.earned_points;
+          return `+${row.earned_points}`;
         } else {
-          return "-" + row.points_cost;
+          return row.earned_points - row.points_cost > 0
+            ? `+${row.earned_points - row.points_cost}`
+            : `${row.earned_points - row.points_cost}`;
         }
       },
+      // cell: (row) => (
+      //   <span
+      //     style={{
+      //       color: row.earned_points - row.points_cost > 0 ? "green" : "red",
+      //     }}
+      //   >
+      //     {row.earned_points - row.points_cost > 0
+      //       ? `+${row.earned_points - row.points_cost}`
+      //       : `${row.earned_points - row.points_cost}`}
+      //   </span>
+      // ),
     },
   ];
-  const { records, isLoadingRecords, recordsError } =
-    useMemberTransactionRecords("8b9acdef-b856-4c78-ac16-36d199737957");
-  console.log(records);
-  if (isLoadingRecords) return <Spinner />;
-  if (recordsError) return <ErrorMessage errorMessage={recordsError.message} />;
+
   return (
     <DataTable
       columns={columns}
-      data={records}
+      data={expendedData}
       pagination
       customStyles={customStyles}
       paginationComponentOptions={paginationComponentOptions}

--- a/src/components/table/MemberInfoPointTable.jsx
+++ b/src/components/table/MemberInfoPointTable.jsx
@@ -2,228 +2,56 @@
 import DataTable from "react-data-table-component";
 import { customStyles, paginationComponentOptions } from "@/data/constants";
 import { useMemberTransactionRecords } from "@/hooks/useBoxTransactions";
-
-// 假資料
-const tempData = [
-  {
-    time: "2024-02-01 10:30",
-    content: "回收 4 個紙箱",
-    site: "台南圖書館",
-    pointChange: "+50",
-    totalPoints: "1050",
-  },
-  {
-    time: "2024-02-02 15:45",
-    content: "購買 1 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+10",
-    totalPoints: "1060",
-  },
-  {
-    time: "2024-02-03 09:15",
-    content: "回收 1 個紙箱",
-    site: "葉子小舖",
-    pointChange: "+100",
-    totalPoints: "1160",
-  },
-  {
-    time: "2024-02-04 14:20",
-    content: "購買 1 個紙箱",
-    site: "台南圖書館",
-    pointChange: "-500",
-    totalPoints: "660",
-  },
-  {
-    time: "2024-02-05 11:45",
-    content: "回收 2 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+200",
-    totalPoints: "860",
-  },
-  {
-    time: "2024-02-01 10:30",
-    content: "回收 4 個紙箱",
-    site: "台南圖書館",
-    pointChange: "+50",
-    totalPoints: "1050",
-  },
-  {
-    time: "2024-02-02 15:45",
-    content: "購買 1 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+10",
-    totalPoints: "1060",
-  },
-  {
-    time: "2024-02-03 09:15",
-    content: "回收 1 個紙箱",
-    site: "葉子小舖",
-    pointChange: "+100",
-    totalPoints: "1160",
-  },
-  {
-    time: "2024-02-04 14:20",
-    content: "購買 1 個紙箱",
-    site: "台南圖書館",
-    pointChange: "-500",
-    totalPoints: "660",
-  },
-  {
-    time: "2024-02-05 11:45",
-    content: "回收 2 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+200",
-    totalPoints: "860",
-  },
-  {
-    time: "2024-02-01 10:30",
-    content: "回收 4 個紙箱",
-    site: "台南圖書館",
-    pointChange: "+50",
-    totalPoints: "1050",
-  },
-  {
-    time: "2024-02-02 15:45",
-    content: "購買 1 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+10",
-    totalPoints: "1060",
-  },
-  {
-    time: "2024-02-03 09:15",
-    content: "回收 1 個紙箱",
-    site: "葉子小舖",
-    pointChange: "+100",
-    totalPoints: "1160",
-  },
-  {
-    time: "2024-02-04 14:20",
-    content: "購買 1 個紙箱",
-    site: "台南圖書館",
-    pointChange: "-500",
-    totalPoints: "660",
-  },
-  {
-    time: "2024-02-05 11:45",
-    content: "回收 2 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+200",
-    totalPoints: "860",
-  },
-  {
-    time: "2024-02-01 10:30",
-    content: "回收 4 個紙箱",
-    site: "台南圖書館",
-    pointChange: "+50",
-    totalPoints: "1050",
-  },
-  {
-    time: "2024-02-02 15:45",
-    content: "購買 1 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+10",
-    totalPoints: "1060",
-  },
-  {
-    time: "2024-02-03 09:15",
-    content: "回收 1 個紙箱",
-    site: "葉子小舖",
-    pointChange: "+100",
-    totalPoints: "1160",
-  },
-  {
-    time: "2024-02-04 14:20",
-    content: "購買 1 個紙箱",
-    site: "台南圖書館",
-    pointChange: "-500",
-    totalPoints: "660",
-  },
-  {
-    time: "2024-02-05 11:45",
-    content: "回收 2 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+200",
-    totalPoints: "860",
-  },
-  {
-    time: "2024-02-01 10:30",
-    content: "回收 4 個紙箱",
-    site: "台南圖書館",
-    pointChange: "+50",
-    totalPoints: "1050",
-  },
-  {
-    time: "2024-02-02 15:45",
-    content: "購買 1 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+10",
-    totalPoints: "1060",
-  },
-  {
-    time: "2024-02-03 09:15",
-    content: "回收 1 個紙箱",
-    site: "葉子小舖",
-    pointChange: "+100",
-    totalPoints: "1160",
-  },
-  {
-    time: "2024-02-04 14:20",
-    content: "購買 1 個紙箱",
-    site: "台南圖書館",
-    pointChange: "-500",
-    totalPoints: "660",
-  },
-  {
-    time: "2024-02-05 11:45",
-    content: "回收 2 個紙箱",
-    site: "米米小吃店",
-    pointChange: "+200",
-    totalPoints: "860",
-  },
-];
+import { formatUTCTimestamp } from "@/utils/helpers";
+import Spinner from "../Spinner";
+import ErrorMessage from "../ErrorMessage";
 
 const MemberInfoPointTable = () => {
+  const { records, isLoadingRecords, recordsError } =
+    useMemberTransactionRecords();
   // 欄位
+
+  if (isLoadingRecords) <Spinner />;
+  if (recordsError) <ErrorMessage errorMessage={recordsError.message} />;
+
   const columns = [
     {
       name: "交易時間",
-      selector: (row) => row.time,
+      selector: (row) => formatUTCTimestamp(row.created_at),
     },
     {
       name: "交易內容",
-      selector: (row) => row.content,
+      selector: (row) => `${row.transaction_type} ${row.boxes.length} 紙箱`,
     },
     {
       name: "交易站點",
-      selector: (row) => row.site,
+      selector: (row) => row.station_name_snapshot,
     },
     {
       name: "積分變化",
-      selector: (row) => row.pointChange,
+      selector: (row) => row.earned_points - row.points_cost,
       cell: (row) => (
         <span
           style={{
-            color: row.pointChange.startsWith("+") ? "green" : "red",
+            color: row.earned_points - row.points_cost > 0 ? "green" : "red",
           }}
         >
-          {row.pointChange}
+          {row.earned_points - row.points_cost > 0
+            ? `+${row.earned_points - row.points_cost}`
+            : `${row.earned_points - row.points_cost}`}
         </span>
       ),
     },
     {
       name: "積分總計",
-      selector: (row) => row.totalPoints,
+      selector: (row) => row.total_points,
     },
   ];
-
-  const { records, isLoadingRecords, recordsError } =
-    useMemberTransactionRecords("8b9acdef-b856-4c78-ac16-36d199737957");
-  console.log(records);
 
   return (
     <DataTable
       columns={columns}
-      data={tempData}
+      data={records}
       pagination
       customStyles={customStyles}
       paginationComponentOptions={paginationComponentOptions}

--- a/src/hooks/useBoxTransactions.js
+++ b/src/hooks/useBoxTransactions.js
@@ -24,8 +24,9 @@ export function useAdminTransactionRecords() {
     isLoading: isLoadingRecords,
     error: recordsError,
   } = useQuery({
-    queryKey: ["boxes-transactions", stationId],
+    queryKey: ["boxes-transactions", "admin"],
     queryFn: () => apiGetAdminTransactionRecords(stationId),
+    enabled: !!stationId,
   });
 
   return { records, isLoadingRecords, recordsError };
@@ -41,14 +42,21 @@ export function useAdminTransactionRecords() {
  *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
  *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
  */
-export function useMemberTransactionRecords(userId) {
+export function useMemberTransactionRecords() {
+  const queryClient = useQueryClient();
+  const currentMember = queryClient.getQueryData(["member"]);
+  const memberId = currentMember?.user?.id;
+
+  console.log(memberId);
+
   const {
     data: records,
     isLoading: isLoadingRecords,
     error: recordsError,
   } = useQuery({
-    queryKey: ["boxes-transactions", userId],
-    queryFn: () => apiGetMemberTransactionRecords(userId),
+    queryKey: ["boxes-transactions", "normal"],
+    queryFn: () => apiGetMemberTransactionRecords(memberId),
+    enabled: !!memberId,
   });
 
   return { records, isLoadingRecords, recordsError };

--- a/src/hooks/useBoxTransactions.js
+++ b/src/hooks/useBoxTransactions.js
@@ -47,8 +47,6 @@ export function useMemberTransactionRecords() {
   const currentMember = queryClient.getQueryData(["member"]);
   const memberId = currentMember?.user?.id;
 
-  console.log(memberId);
-
   const {
     data: records,
     isLoading: isLoadingRecords,

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -79,8 +79,9 @@ export function useBoxesForScraping() {
     isLoading: isLoadingBoxes,
     error: boxesError,
   } = useQuery({
-    queryKey: ["boxes", "scrap", stationId],
+    queryKey: ["boxes", "scrap"],
     queryFn: () => apiGetBoxesForScraping(stationId),
+    enabled: !!stationId,
   });
 
   return { boxes, isLoadingBoxes, boxesError };
@@ -95,14 +96,18 @@ export function useBoxesForScraping() {
  *   - `isLoadingBoxes` {boolean} - 是否正在加載資料
  *   - `BoxesError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
  */
-export function useBoxesTotalForSelling(stationId) {
+export function useBoxesTotalForSelling() {
+  const queryClient = useQueryClient();
+  const station = queryClient.getQueryData(["stationAdmin"]);
+  const stationId = station?.id;
   const {
     data: boxes,
     isLoading: isLoadingBoxes,
     error: boxesError,
   } = useQuery({
-    queryKey: ["boxes", stationId],
+    queryKey: ["boxes", "sale"],
     queryFn: () => apiGetBoxesTotalForSelling(stationId),
+    enabled: !!stationId,
   });
 
   return { boxes, isLoadingBoxes, boxesError };

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -190,14 +190,17 @@ export function useUpdateMultipleBoxes() {
  */
 export function useAddMultipleBoxes() {
   const queryClient = useQueryClient();
+  const station = queryClient.getQueryData(["stationAdmin"]);
+  const stationId = station?.id;
 
   const {
-    mutate: addMultipleBoxes,
+    mutateAsync: addMultipleBoxesAsync,
     error: addedError,
     isPending: isAdding,
     isError,
   } = useMutation({
-    mutationFn: (formData) => apiAddMultipleBoxes(formData),
+    mutationKey: ["addMultipleBoxes"],
+    mutationFn: (formData) => apiAddMultipleBoxes({ formData, stationId }),
     onSuccess: () => {
       toast.success("紙箱新增成功");
       queryClient.invalidateQueries({ queryKey: ["boxes"] }); // 重新獲取最新數據
@@ -207,5 +210,5 @@ export function useAddMultipleBoxes() {
     },
   });
 
-  return { addMultipleBoxes, isAdding, addedError, isError };
+  return { addMultipleBoxesAsync, isAdding, addedError, isError };
 }

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -133,6 +133,7 @@ export function useUpdateBox() {
     isPending: isUpdating,
     isError,
   } = useMutation({
+    mutationKey: ["updateBox"],
     mutationFn: ({ boxId, values }) => apiUpdateBox(boxId, values),
     onSuccess: () => {
       toast.success("更新成功");
@@ -166,6 +167,7 @@ export function useUpdateMultipleBoxes() {
     isPending: isUpdating,
     isError,
   } = useMutation({
+    mutationKey: ["updateMultipleBoxes"],
     mutationFn: ({ boxIds, values }) => apiUpdateMultipleBoxes(boxIds, values),
     onSuccess: () => {
       toast.success("售出成功");

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -52,7 +52,7 @@ export function useBoxesForAdminManaging() {
     isLoading: isLoadingBoxes,
     error: boxesError,
   } = useQuery({
-    queryKey: ["boxes", "managing", stationId],
+    queryKey: ["boxes", "managing"],
     queryFn: () => apiGetBoxesForAdminManaging(stationId),
   });
 

--- a/src/hooks/useCreateTransaction.js
+++ b/src/hooks/useCreateTransaction.js
@@ -27,7 +27,7 @@ export function useCreateTransaction() {
     },
     onError: (err) => {
       console.error(err.message);
-      toast(`新增交易失敗`);
+      toast.error(`${err.message}`);
     },
   });
 

--- a/src/hooks/useCreateTransaction.js
+++ b/src/hooks/useCreateTransaction.js
@@ -1,0 +1,35 @@
+import { apiCreateTransaction } from "@/services/apiBoxTransactions";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+
+export function useCreateTransaction() {
+  // 取得站點資訊
+  const queryClient = useQueryClient();
+  const station = queryClient.getQueryData(["stationAdmin"]);
+  const stationInfo = {
+    station_id: station.id,
+    station_name_snapshot: station.station_name,
+  };
+
+  const {
+    mutateAsync: createTransactionAsync,
+    isPending: isCreating,
+    error: createError,
+  } = useMutation({
+    mutationKey: ["createTransaction"],
+    mutationFn: ({ transaction, memberId }) =>
+      apiCreateTransaction({ transaction, stationInfo, memberId }),
+    onSuccess: () => {
+      toast.success("新增交易成功");
+      queryClient.invalidateQueries({
+        queryKey: ["boxes-transactions", "admin"],
+      });
+    },
+    onError: (err) => {
+      console.error(err.message);
+      toast(`新增交易失敗`);
+    },
+  });
+
+  return { createTransactionAsync, isCreating, createError };
+}

--- a/src/hooks/useMember.js
+++ b/src/hooks/useMember.js
@@ -9,7 +9,6 @@ export function useMember() {
   } = useQuery({
     queryKey: ["member"],
     queryFn: () => apiGetMember(),
-    // staleTime: 1000 * 60 * 10, // ✅ 10 分鐘內不重新 fetch，減少不必要的渲染
   });
 
   const roles = member?.user?.user_metadata?.roles || [];

--- a/src/hooks/useSignIn.js
+++ b/src/hooks/useSignIn.js
@@ -16,9 +16,9 @@ export function useSignIn() {
       queryClient.setQueryData(["member"], member);
 
       // 2. token 存入 cookies
-      // const { session } = member;
-      // const expires = new Date(session.expires_at * 1000).toUTCString();
-      // document.cookie = `accessToken=${session.access_token};expires=${expires}`;
+      const { session } = member;
+      const expires = new Date(session.expires_at * 1000).toUTCString();
+      document.cookie = `accessToken=${session.access_token};expires=${expires}`;
 
       // 3. UI 提示訊息
       toast.success(`登入成功`);
@@ -27,7 +27,7 @@ export function useSignIn() {
       navigate("/", { replace: true });
     },
     onError: (error) => {
-      console.log(error.message);
+      console.error(error.message);
       toast.error(`登入失敗，帳號或密碼錯誤`);
     },
   });

--- a/src/services/apiBoxTransactions.js
+++ b/src/services/apiBoxTransactions.js
@@ -1,4 +1,6 @@
+import { getTimestamp } from "@/utils/helpers";
 import supabase from "./supabase";
+import supabaseAdmin from "./supabaseAdmin";
 
 /**
  * 從 Supabase 取得 管理者-紙箱交易紀錄的交易資料
@@ -70,6 +72,160 @@ export async function apiGetTransactionsCounts(userId) {
 
     const transactionsCounts = boxTransactions.length;
     return transactionsCounts;
+  } catch (error) {
+    throw new Error(error.message);
+  }
+}
+
+// {
+//     "userId": "8b9acdef-b856-4c78-ac16-36d199737957",
+//     "selectedRows": [
+//         {
+//             "id": 152,
+//             "created_at": "2024-01-30T00:00:00+00:00",
+//             "updated_at": "2024-11-25T00:00:00+00:00",
+//             "size": "特大",
+//             "condition": "全新",
+//             "status": "可認領",
+//             "retention_days": 30,
+//             "image_url": "https://fakeimg.pl/300/",
+//             "cash_value": 20,
+//             "point_value": 9,
+//             "station_id": 1,
+//             "user_id": "1725f7bc-7108-4d31-ae2f-b3d68393d6a5"
+//         },
+//         {
+//             "id": 29,
+//             "created_at": "2024-05-15T00:00:00+00:00",
+//             "updated_at": "2024-11-14T00:00:00+00:00",
+//             "size": "小",
+//             "condition": "全新",
+//             "status": "可認領",
+//             "retention_days": 30,
+//             "image_url": "https://fakeimg.pl/300/",
+//             "cash_value": 8,
+//             "point_value": 6,
+//             "station_id": 1,
+//             "user_id": "8b9acdef-b856-4c78-ac16-36d199737957"
+//         }
+//     ],
+//     "paymentMethod": "cash"
+// }
+
+//  {
+//     id: 192,
+//     created_at: "2025-01-29T00:00:00+00:00",
+//     transaction_type: "回收",
+//     cash_cost: 0,
+//     points_cost: 0,
+//     earned_points: 3,
+//     total_points: 17,
+//     station_id: 7,
+//     station_name_snapshot: "無日",
+//     user_id: "34cdab41-2bdf-4dd9-8c35-0cb7c15a4d0b",
+//     user_name_snapshot: "阮彥博",
+//     status: "成功",
+//     boxes: [
+//       {
+//         size: "大",
+//         box_id: 99,
+//         condition: "差",
+//         cash_value: 4,
+//         point_value: 3,
+//       },
+//     ],
+//   };
+
+// {
+//     "transaction_type": "認領",
+//     "cash_cost": 28,
+//     "points_cost": 0,
+//     "earned_points": 2,
+//     "boxes": [
+//         {
+//             "size": "特大",
+//             "box_id": 152,
+//             "condition": "全新",
+//             "cash_value": 20,
+//             "point_value": 9
+//         },
+//         {
+//             "size": "小",
+//             "box_id": 29,
+//             "condition": "全新",
+//             "cash_value": 8,
+//             "point_value": 6
+//         }
+//     ]
+// }
+export async function apiCreateTransaction({
+  transaction,
+  stationInfo,
+  memberId,
+}) {
+  console.log(transaction, stationInfo, memberId);
+  let total_points;
+  let user_name_snapshot;
+  try {
+    if (memberId) {
+      const { data, error } =
+        await supabaseAdmin.auth.admin.getUserById(memberId);
+      total_points =
+        data.user.user_metadata.points + 2 - transaction.points_cost;
+      user_name_snapshot = data.user.user_metadata.display_name;
+
+      if (error) {
+        console.error(error);
+        throw new Error("取得用戶失敗");
+      }
+    }
+
+    console.log(user_name_snapshot, total_points);
+
+    const newTransaction = {
+      ...transaction,
+      ...stationInfo,
+      boxes: [...transaction.boxes],
+      earned_points: 2,
+      total_points: total_points ? total_points : null,
+      user_id: memberId,
+      user_name_snapshot: user_name_snapshot ? user_name_snapshot : null,
+      created_at: getTimestamp(),
+    };
+
+    console.log(newTransaction);
+
+    const { data: transactionData, error } = await supabase
+      .from("box-transactions")
+      .insert([newTransaction])
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    console.log("transactionData", transactionData);
+
+    if (total_points) {
+      const { data: user, error } =
+        await supabaseAdmin.auth.admin.updateUserById(memberId, {
+          user_metadata: { points: total_points },
+        });
+      if (error) {
+        console.error(error);
+
+        const { error } = await supabase
+          .from("box-transactions")
+          .delete()
+          .eq("id", transactionData.id);
+
+        throw new Error("更新用戶點數失敗");
+      }
+      console.log(user);
+    }
+
+    console.log("final data", transactionData);
+
+    return transactionData;
   } catch (error) {
     throw new Error(error.message);
   }

--- a/src/services/apiBoxTransactions.js
+++ b/src/services/apiBoxTransactions.js
@@ -170,14 +170,16 @@ export async function apiCreateTransaction({
     if (memberId) {
       const { data, error } =
         await supabaseAdmin.auth.admin.getUserById(memberId);
-      total_points =
-        data.user.user_metadata.points + 2 - transaction.points_cost;
-      user_name_snapshot = data.user.user_metadata.display_name;
 
       if (error) {
         console.error(error);
-        throw new Error("取得用戶失敗");
+        throw new Error(`無法取該用戶，ID： ${memberId}`);
       }
+      total_points =
+        data.user.user_metadata.points +
+        transaction.earned_points -
+        transaction.points_cost;
+      user_name_snapshot = data.user.user_metadata.display_name;
     }
 
     console.log(user_name_snapshot, total_points);
@@ -186,7 +188,7 @@ export async function apiCreateTransaction({
       ...transaction,
       ...stationInfo,
       boxes: [...transaction.boxes],
-      earned_points: 2,
+
       total_points: total_points ? total_points : null,
       user_id: memberId,
       user_name_snapshot: user_name_snapshot ? user_name_snapshot : null,

--- a/src/services/apiBoxTransactions.js
+++ b/src/services/apiBoxTransactions.js
@@ -82,7 +82,6 @@ export async function apiCreateTransaction({
   stationInfo,
   memberId,
 }) {
-  console.log(transaction, stationInfo, memberId);
   let total_points;
   let user_name_snapshot;
   try {
@@ -104,9 +103,6 @@ export async function apiCreateTransaction({
 
       const recordsData = records.length > 0 ? records[0] : null;
 
-      console.log(transaction.earned_points - transaction.points_cost);
-      console.log(recordsData);
-
       total_points = recordsData
         ? recordsData.total_points +
           transaction.earned_points -
@@ -126,8 +122,6 @@ export async function apiCreateTransaction({
       created_at: getTimestamp(),
     };
 
-    console.log(newTransaction);
-
     const { data: transactionData, error } = await supabase
       .from("box-transactions")
       .insert([newTransaction])
@@ -136,13 +130,13 @@ export async function apiCreateTransaction({
 
     if (error) throw error;
 
-    console.log("transactionData", transactionData);
-
     if (total_points) {
-      const { data: user, error } =
-        await supabaseAdmin.auth.admin.updateUserById(memberId, {
+      const { error } = await supabaseAdmin.auth.admin.updateUserById(
+        memberId,
+        {
           user_metadata: { points: total_points },
-        });
+        },
+      );
       if (error) {
         console.error(error);
 
@@ -153,10 +147,7 @@ export async function apiCreateTransaction({
 
         throw new Error("更新用戶點數失敗");
       }
-      console.log(user);
     }
-
-    console.log("final data", transactionData);
 
     return transactionData;
   } catch (error) {

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -196,7 +196,7 @@ export async function apiUpdateMultipleBoxes(boxIds, values) {
  * @param {Array} formData.boxes - 需要新增的紙箱資料陣列
  * @returns {Promise<Array>} 新增的紙箱資料或錯誤
  */
-export async function apiAddMultipleBoxes(formData) {
+export async function apiAddMultipleBoxes({ formData, stationId }) {
   try {
     const formattedBoxes = formData.boxes.map((box) => ({
       created_at: getTimestamp(),
@@ -208,7 +208,7 @@ export async function apiAddMultipleBoxes(formData) {
       cash_value: Number(box.cash_value),
       point_value: Number(box.points),
       retention_days: Number(box.retention_days) || 0,
-      station_id: formData.station_id,
+      station_id: stationId,
       user_id: formData.user_id,
     }));
 

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -103,7 +103,7 @@ export async function apiGetBoxesTotalForSelling(stationId) {
   try {
     let { data: boxes, error } = await supabase
       .from("boxes")
-      .select("size")
+      .select("*")
       .in("status", ["可認領"])
       .eq("station_id", stationId)
       .order("id", { ascending: true });

--- a/src/services/supabaseAdmin.js
+++ b/src/services/supabaseAdmin.js
@@ -1,0 +1,8 @@
+import { createClient } from "@supabase/supabase-js";
+
+const { VITE_SUPABASE_URL, VITE_SUPABASE_ADMIN_KEY } = import.meta.env;
+
+const supabaseUrl = VITE_SUPABASE_URL;
+const supabaseKey = VITE_SUPABASE_ADMIN_KEY;
+const supabaseAdmin = createClient(supabaseUrl, supabaseKey);
+export default supabaseAdmin;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,10 +1,24 @@
 export function getTimestamp() {
-  const now = new Date();
+  return new Date().toISOString();
+}
 
-  // 取得 ISO 格式：2025-02-02T07:36:28.117Z
-  let isoString = now.toISOString();
+export function formatUTCTimestamp(utcTimestamp, timeZone = "Asia/Taipei") {
+  const date = new Date(utcTimestamp);
 
-  return isoString;
+  const options = {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  };
+
+  return new Intl.DateTimeFormat("zh-TW", options)
+    .format(date)
+    .replace(/\//g, "-")
+    .replace(",", "");
 }
 
 /**


### PR DESCRIPTION
### 主要變更

1.  apiBoxTransactions.js：新增「新增交易記錄」supabase 請求邏輯
2. 新增 useCreateTransaction custom hook，使用 react query 管理新增交易請求 apiCreateTransaction 
3. AdminTrade、AdminAddBoxes 串接 useCreateTransaction 新增交易邏輯
4. 串接 4-3、4-4 會員積分記錄、交易記錄
5. 串接 5-5 站點管理交易記錄

### 次要變更
1. AdminTradeTable 交易紙箱「搜尋框」優化支援搜尋 紙箱 id 、尺寸、 新舊
2. fix: 登入後於首頁重整，自動登出問題
3. fix: 會員 & 管理者 基本資訊編輯表格，編輯一半取消編輯，欄位回到初始值

- [x] 測試新增紙箱流程是否能順利運行？
- [x] 完成新增之後管理者交易記錄，是否有新的交易記錄？
- [x] 完成新增之後該用戶的交易記錄、積分記錄，是否有新的資料？

- [x] 測試交易紙箱流程是否能順利運行？
- [x] 完成交易之後管理者交易記錄，是否有新的交易記錄？
- [x] 完成交易之後該用戶的交易記錄、積分記錄，是否有新的資料？

- [x] 登入後跳轉首頁，重新整理後是否還會維持登入狀態？
- [x] 會員資訊編輯表單、站點資訊編輯表單，編輯至一半關掉編輯，是否會回復修改前狀態？