### PR TITLE
Feature: 新增 刪除紙箱紀錄API

### DIFF
--- a/src/components/dialog/DeleteBoxDialog.jsx
+++ b/src/components/dialog/DeleteBoxDialog.jsx
@@ -11,26 +11,34 @@ import {
 } from "@/components/ui/dialog";
 
 import toast from "react-hot-toast";
-import { useUpdateBox } from "@/hooks/useBoxes";
+import { useDeleteBox, useUpdateBox } from "@/hooks/useBoxes";
 
 function DeleteBoxDialog({ row, icons }) {
   const { updateBox } = useUpdateBox();
+  const { deleteBox } = useDeleteBox();
   const [open, setOpen] = useState(false);
-  const result = ["售出", "自用", "可認領"].includes(row.status)
-    ? "回收"
-    : "刪除";
+  const result = ["自用", "可認領"].includes(row.status) ? "回收" : "刪除";
 
   const handleUpdate = () => {
+    if (result === "刪除") {
+      deleteBox(
+        { boxId: row.id },
+        {
+          onSuccess: () => {
+            setOpen(false);
+          },
+        },
+      );
+      return;
+    }
     const formattedValues = {
       status: "報廢",
       retention_days: Number(row.retention_days),
     };
-
     updateBox(
       { boxId: row.id, values: formattedValues },
       {
         onSuccess: () => {
-          toast.success(`${result}成功`);
           setOpen(false);
         },
       },

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -6,6 +6,7 @@ import {
   apiUpdateBox,
   apiUpdateMultipleBoxes,
   apiAddMultipleBoxes,
+  apiDeleteBox,
 } from "@/services/apiBoxes";
 import toast from "react-hot-toast";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -114,6 +115,38 @@ export function useBoxesTotalForSelling() {
 }
 
 /**
+ * 自訂 Hook：使用 React Query 來批量新增紙箱資料
+ *
+ * @returns {Object} 返回包含四個屬性的物件：
+ *   - `addMultipleBoxes` {Function} - 用於觸發批量新增的函式，接收 `formData`
+ *   - `isAdding` {boolean} - 是否正在新增資料
+ *   - `addedError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
+ *   - `isError` {boolean} - 是否發生錯誤
+ */
+export function useDeleteBox() {
+  const queryClient = useQueryClient();
+
+  const {
+    mutateAsync: deleteBox,
+    error: deletedError,
+    isPending: isDeleting,
+    isError,
+  } = useMutation({
+    mutationKey: ["deleteMultipleBoxes"],
+    mutationFn: ({ boxId }) => apiDeleteBox(boxId),
+    onSuccess: () => {
+      toast.success("刪除成功");
+      queryClient.invalidateQueries({ queryKey: ["boxes"] }); // 重新獲取最新數據
+    },
+    onError: (error) => {
+      toast.error(`刪除失敗: ${error.message}`);
+    },
+  });
+
+  return { deleteBox, isDeleting, deletedError, isError };
+}
+
+/**
  * 自訂 Hook：使用 React Query 來更新單一筆紙箱資料
  *
  * 使用 `useMutation` 來向 API 發送更新請求，並在成功時重新整理紙箱數據。
@@ -136,11 +169,11 @@ export function useUpdateBox() {
     mutationKey: ["updateBox"],
     mutationFn: ({ boxId, values }) => apiUpdateBox(boxId, values),
     onSuccess: () => {
-      toast.success("更新成功");
+      toast.success("回收成功");
       queryClient.invalidateQueries({ queryKey: ["boxes"] }); // 重新請求最新的紙箱列表
     },
     onError: (error) => {
-      toast.error(`更新失敗: ${error.message}`);
+      toast.error(`回收失敗: ${error.message}`);
     },
   });
 

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -132,7 +132,7 @@ export function useDeleteBox() {
     isPending: isDeleting,
     isError,
   } = useMutation({
-    mutationKey: ["deleteMultipleBoxes"],
+    mutationKey: ["deleteBox"],
     mutationFn: ({ boxId }) => apiDeleteBox(boxId),
     onSuccess: () => {
       toast.success("刪除成功");

--- a/src/hooks/useBoxes.js
+++ b/src/hooks/useBoxes.js
@@ -115,12 +115,12 @@ export function useBoxesTotalForSelling() {
 }
 
 /**
- * 自訂 Hook：使用 React Query 來批量新增紙箱資料
+ * 自訂 Hook：使用 React Query 來刪除紙箱資料
  *
  * @returns {Object} 返回包含四個屬性的物件：
- *   - `addMultipleBoxes` {Function} - 用於觸發批量新增的函式，接收 `formData`
- *   - `isAdding` {boolean} - 是否正在新增資料
- *   - `addedError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
+ *   - `deleteBox` {Function} - 用於觸發刪除操作的函式，接收 `boxId`
+ *   - `isDeleting` {boolean} - 是否正在刪除資料
+ *   - `deletedError` {Error|null} - 若請求發生錯誤，將包含錯誤物件，否則為 `null`
  *   - `isError` {boolean} - 是否發生錯誤
  */
 export function useDeleteBox() {

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -119,6 +119,23 @@ export async function apiGetBoxesTotalForSelling(stationId) {
   }
 }
 
+export async function apiDeleteBox(boxId) {
+  try {
+    const { data, error } = await supabase
+      .from("boxes")
+      .delete()
+      .eq("id", boxId)
+      .select();
+    if (error) throw error;
+    return data;
+  } catch (error) {
+    // supabase 錯誤內容
+    console.error("刪除 Box 發生錯誤:", error);
+    // UI 顯示的錯誤內容
+    throw new Error("無法刪除 boxes 資料，請稍後再試");
+  }
+}
+
 /**
  * 從 Supabase 更新單一筆紙箱資料
  *

--- a/src/services/apiBoxes.js
+++ b/src/services/apiBoxes.js
@@ -46,7 +46,8 @@ export async function apiGetBoxesForAdminManaging(stationId) {
       .from("boxes")
       .select("*")
       .in("status", ["自用", "可認領"])
-      .eq("station_id", stationId);
+      .eq("station_id", stationId)
+      .order("id", { ascending: true });
 
     if (error) throw error;
 


### PR DESCRIPTION
### 主要更改
- 新增 `apiDeleteBox` 刪除紙箱API
- 封裝成 `useDeleteBox` hook
- 在 `DeleteBoxDialog.jsx` 串接刪除紙箱功能

### 測試方法
- [x] 在5-3 回收按鈕回收一筆紙箱紀錄，並提示`回收成功`
- [x] 在5-4 刪除按鈕刪除一筆紙箱紀錄，並提示`刪除成功`
- [x] 到supabase `boxes` 檢查該筆資料是否正確刪除