### PR TITLE
Fix : 會員資訊頁面 錯誤修復 & 樣式調整

### DIFF
--- a/src/components/ResponsiveSwiper.jsx
+++ b/src/components/ResponsiveSwiper.jsx
@@ -67,7 +67,10 @@ function ResponsiveSwiper({ initialSlide, memberLevel }) {
         <SwiperSlide>
           <div className={style.cardContainer}>
             <div className={style.card}>
-              <img className="" src={beginner} alt="" />
+              <img
+                src={beginner}
+                alt="滿面笑容的小孩戴著黃色帽子、黃色眼鏡，背著黃色背包"
+              />
               <p className={style.cardTitle}>箱遇路人</p>
             </div>
             <button
@@ -92,9 +95,8 @@ function ResponsiveSwiper({ initialSlide, memberLevel }) {
           <div className={style.cardContainer}>
             <div className={style.card}>
               <img
-                className=""
                 src={memberLevel < 2 ? young_locked : young}
-                alt=""
+                alt="駕駛引曳機的青年"
               />
               <p className={style.cardTitle}>返箱青年</p>
             </div>
@@ -120,9 +122,8 @@ function ResponsiveSwiper({ initialSlide, memberLevel }) {
           <div className={style.cardContainer}>
             <div className={style.card}>
               <img
-                className=""
                 src={memberLevel < 3 ? village_master_locked : village_master}
-                alt=""
+                alt="手上停了一隻鳥，在樹下坐著椅子的白鬍子村長"
               />
               <p className={style.cardTitle}>箱村村長</p>
             </div>
@@ -148,9 +149,8 @@ function ResponsiveSwiper({ initialSlide, memberLevel }) {
           <div className={style.cardContainer}>
             <div className={style.card}>
               <img
-                className=""
                 src={memberLevel < 4 ? guardian_locked : guardian}
-                alt=""
+                alt="戴著綠色帽子，背後有翅膀的可愛稻草人"
               />
               <p className={style.cardTitle}>箱村守護者</p>
             </div>

--- a/src/features/admin/DashboardNav.jsx
+++ b/src/features/admin/DashboardNav.jsx
@@ -5,9 +5,9 @@ const style = {
   mainNavContainer:
     "container mx-auto flex w-full justify-center gap-2 md:justify-start",
   mainNav:
-    "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-main-600 text-white",
-  mainNavActive:
     "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9] bg-white text-[#6F6F6F]",
+  mainNavActive:
+    "inline-flex h-[77px] grow md:grow-0 w-[168px] items-center justify-center rounded-2xl rounded-b-none border border-b-0 border-[#D9D9D9 bg-main-600 text-white",
 };
 
 function DashboardNav({ role }) {

--- a/src/features/member/MemberInfo.jsx
+++ b/src/features/member/MemberInfo.jsx
@@ -78,7 +78,7 @@ function MemberInfo() {
   ]);
 
   return (
-    <div className="w-full px-10 text-center">
+    <div className="w-full px-2 text-center sm:px-5 md:px-10">
       <div className="my-15">
         <div className="mb-10">
           <p className="mb-6 text-base md:text-2xl">
@@ -133,7 +133,7 @@ function MemberInfo() {
                   {pointNum !== "" ? pointNum : "載入中..."}
                 </p>
                 <p className={`${style.cardText} ${style.responsiveSettings}`}>
-                  Points
+                  點
                 </p>
               </div>
               <div
@@ -172,7 +172,7 @@ function MemberInfo() {
               <p className={style.cardNumber}>
                 {pointNum !== "" ? pointNum : "載入中..."}
               </p>
-              <p className={style.cardText}>Points</p>
+              <p className={style.cardText}>點</p>
             </div>
             <div className={`${style.cardContainer} justify-center gap-4`}>
               <img src={box_count} alt="" className="justify-self-center" />

--- a/src/features/member/MemberInfo.jsx
+++ b/src/features/member/MemberInfo.jsx
@@ -121,7 +121,7 @@ function MemberInfo() {
               >
                 <img
                   src={points_icon}
-                  alt=""
+                  alt="金幣圖示"
                   className={`${style.responsiveSettings}`}
                 />
                 <p className={`${style.cardText} ${style.responsiveSettings}`}>
@@ -141,7 +141,7 @@ function MemberInfo() {
               >
                 <img
                   src={box_count}
-                  alt=""
+                  alt="紙箱圖示"
                   className={`${style.responsiveSettings}`}
                 />
                 <p className={`${style.cardText} ${style.responsiveSettings}`}>
@@ -167,7 +167,11 @@ function MemberInfo() {
           {/* 2號 div 的手機版位置 */}
           <div className="order-3 flex flex-col gap-5 rounded md:hidden">
             <div className={`${style.cardContainer} justify-center gap-4`}>
-              <img src={points_icon} alt="" className="justify-self-center" />
+              <img
+                src={points_icon}
+                alt="金幣圖示"
+                className="justify-self-center"
+              />
               <p className={style.cardText}>當前積分</p>
               <p className={style.cardNumber}>
                 {pointNum !== "" ? pointNum : "載入中..."}
@@ -175,7 +179,11 @@ function MemberInfo() {
               <p className={style.cardText}>點</p>
             </div>
             <div className={`${style.cardContainer} justify-center gap-4`}>
-              <img src={box_count} alt="" className="justify-self-center" />
+              <img
+                src={box_count}
+                alt="紙箱圖示"
+                className="justify-self-center"
+              />
               <p className={style.cardText}>轉運紙箱</p>
               <p className={style.cardNumber}>
                 {transactionNumber !== "" ? transactionNumber : "載入中..."}

--- a/src/features/member/MemberInfo.jsx
+++ b/src/features/member/MemberInfo.jsx
@@ -78,9 +78,9 @@ function MemberInfo() {
   ]);
 
   return (
-    <div className="w-full p-10 text-center">
-      <div className="my-20">
-        <div className="my-10">
+    <div className="w-full px-10 text-center">
+      <div className="my-15">
+        <div className="mb-10">
           <p className="mb-6 text-base md:text-2xl">
             幫助紙箱君順利搭上返箱專車，繼續旅行吧！
           </p>

--- a/src/index.css
+++ b/src/index.css
@@ -74,6 +74,8 @@
     --chart-5: 27 87% 67%;
 
     --radius: 0.5rem;
+
+    --swiper-navigation-color: #563b28;
   }
   .dark {
     --background: 0 0% 3.9%;


### PR DESCRIPTION
### **主要修正內容：**
區塊：會員頁面
- Tab 會員 / 管理者樣式對調
- 調整 Tab 下方 padding 
- 調整左右 padding
- 調整"幫助紙箱君…" RWD (解析度 336 以下無視)
- 表單錯誤提示修正
- Swiper 箭頭改為主色系
- img 補上 alt 屬性