### PR TITLE
fix: 修正管理者頁面

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -4,7 +4,7 @@ export const customStyles = {
     style: {
       border: "1px solid #d9d9d9",
       boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
-      padding: "8px",
+      fontSize: "16px",
     },
   },
   headRow: {
@@ -12,6 +12,7 @@ export const customStyles = {
       backgroundColor: "#F5F1E8",
       borderBottomColor: "#d9d9d9",
       fontWeight: "bold",
+      fontSize: "14px",
       color: "#3d3d3d",
     },
   },

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -4,6 +4,7 @@ export const customStyles = {
     style: {
       border: "1px solid #d9d9d9",
       boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+      padding: "8px",
     },
   },
   headRow: {

--- a/src/features/admin/AdminInfoForm.jsx
+++ b/src/features/admin/AdminInfoForm.jsx
@@ -148,30 +148,29 @@ function AdminInfoForm({ station }) {
             <h6 className="text-main-600">營業時間</h6>
           </label>
           {daysOfWeek.map((day, index) => (
-            <div
-              key={index}
-              className="flex items-center space-x-1 md:space-x-2"
-            >
+            <div key={index}>
               <input
                 type="checkbox"
                 {...register(`station_daily_hours.${index}.is_business_day`)}
                 disabled={!isEditing}
               />
-              <span className="text-nowrap p-1">{day}</span>
-              <input
-                {...register(`station_daily_hours.${index}.open_time`)}
-                placeholder="開店時間"
-                type="time"
-                disabled={!isEditing}
-                className="text-md w-full rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
-              />
-              <input
-                {...register(`station_daily_hours.${index}.close_time`)}
-                placeholder="關店時間"
-                type="time"
-                disabled={!isEditing}
-                className="text-md w-full rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
-              />
+              <span className="text-nowrap px-2">{day}</span>
+              <div className="flex items-center gap-2 px-5">
+                <input
+                  {...register(`station_daily_hours.${index}.open_time`)}
+                  placeholder="開店時間"
+                  type="time"
+                  disabled={!isEditing}
+                  className="text-md w-full rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
+                />
+                <input
+                  {...register(`station_daily_hours.${index}.close_time`)}
+                  placeholder="關店時間"
+                  type="time"
+                  disabled={!isEditing}
+                  className="text-md w-full rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
+                />
+              </div>
             </div>
           ))}
         </div>

--- a/src/features/admin/AdminInfoForm.jsx
+++ b/src/features/admin/AdminInfoForm.jsx
@@ -23,6 +23,8 @@ const formSchema = z.object({
 });
 
 import PropTypes from "prop-types";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 AdminInfoForm.propTypes = { station: PropTypes.object };
 
 const daysOfWeek = [
@@ -107,38 +109,41 @@ function AdminInfoForm({ station }) {
         onSubmit={handleSubmit(onSubmit)}
         className="mx-auto max-w-3xl space-y-4 py-6"
       >
-        <div className="flex items-center">
-          <label className="w-1/5">
+        <div className="flex items-center gap-2">
+          <Label htmlFor="station_name" className="w-16">
             <h6 className="text-main-600">站點名稱</h6>
-          </label>
-          <input
+          </Label>
+          <Input
+            id="station_name"
             {...register("station_name")}
             placeholder="輸入店名"
-            className="w-3/5 rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
+            className="w-3/5 rounded-sm border border-neutral-400 p-1 text-gray-700 shadow-none focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent disabled:text-gray-700"
             disabled={!isEditing}
           />
         </div>
 
-        <div className="flex items-center">
-          <label className="w-1/5">
+        <div className="flex items-center gap-2">
+          <Label htmlFor="address" className="w-16">
             <h6 className="text-main-600">地址</h6>
-          </label>
-          <input
+          </Label>
+          <Input
+            id="address"
             {...register("address")}
             placeholder="輸入地址"
-            className="w-3/5 rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
+            className="w-3/5 rounded-sm border border-neutral-400 p-1 text-gray-700 shadow-none focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
             disabled={!isEditing}
           />
         </div>
 
-        <div className="flex items-center">
-          <label className="w-1/5">
+        <div className="flex items-center gap-2">
+          <Label htmlFor="phone" className="w-16">
             <h6 className="text-main-600">電話</h6>
-          </label>
-          <input
+          </Label>
+          <Input
+            id="phone"
             {...register("phone")}
             placeholder="輸入電話"
-            className="w-3/5 rounded-sm border border-neutral-400 p-1 text-gray-700 focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
+            className="w-3/5 rounded-sm border border-neutral-400 p-1 text-gray-700 shadow-none focus:border-main-400 focus:outline-none disabled:border-none disabled:bg-transparent"
             disabled={!isEditing}
           />
         </div>

--- a/src/features/boxes/AdminAddBoxes.jsx
+++ b/src/features/boxes/AdminAddBoxes.jsx
@@ -127,25 +127,26 @@ function AdminAddBoxes() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-main-100 py-6">
-      <div className="w-full max-w-3xl rounded-lg bg-white p-6 shadow-lg">
-        <h2 className="mb-4 text-center text-2xl font-bold text-main-600">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-main-100 py-6">
+      <div className="mb-3 flex w-1/3 justify-center">
+        <p className="my-5 w-full border-b-4 border-b-main-600 pb-5 text-center text-4xl font-bold text-main-600">
           新增紙箱
-        </h2>
-
+        </p>
+      </div>
+      <div className="w-full max-w-5xl rounded-xl bg-white p-6 shadow-lg">
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="mb-4 space-x-4">
-            <label className="font-semibold text-[#3D3D3D]">新增時間:</label>
+            <label className="font-semibold text-main-600">新增時間:</label>
             <input
               type="text"
               {...register("created_at")}
               disabled
-              className="rounded-md bg-transparent px-2 py-1"
+              className="rounded-md bg-transparent px-2 py-1 text-neutral-700"
             />
           </div>
 
           <div className="mb-4 space-x-4">
-            <label className="font-semibold text-[#3D3D3D]">會員編號:</label>
+            <label className="font-semibold text-main-600">會員編號:</label>
             <input
               type="text"
               placeholder="請輸入會員編號"
@@ -180,7 +181,7 @@ function AdminAddBoxes() {
 
           <table className="w-full border-collapse">
             <thead>
-              <tr className="bg-main-100 text-neutral-500">
+              <tr className="bg-main-100 text-neutral-600">
                 <th className="border p-2">編號</th>
                 <th className="border p-2">紙箱大小</th>
                 <th className="border p-2">紙箱保存等級</th>
@@ -280,9 +281,9 @@ function AdminAddBoxes() {
               {errors.boxes.message}
             </p>
           )}
-          <div className="mt-4 font-semibold text-[#3D3D3D]">
+          <div className="mt-4 font-semibold text-main-600">
             積分總計:
-            <span className="font-bold text-main-500">{totalPoints}</span>
+            <span className="ml-4 text-neutral-700">{totalPoints}</span>
           </div>
 
           <div className="mt-6 flex justify-end space-x-4">

--- a/src/features/boxes/AdminAddBoxes.jsx
+++ b/src/features/boxes/AdminAddBoxes.jsx
@@ -292,14 +292,14 @@ function AdminAddBoxes() {
           <div className="mt-6 flex flex-col justify-end gap-4 md:flex-row">
             <button
               type="button"
-              className="btn-cancel order-1"
+              className="btn-cancel order-1 md:w-1/4"
               onClick={() => navigate("/member/admin/boxesTable")}
             >
               取消
             </button>
             <button
               type="submit"
-              className="btn md:order-2"
+              className="btn md:order-2 md:w-1/4"
               disabled={isAdding}
             >
               {isAdding ? "新增中" : "確認"}

--- a/src/features/boxes/AdminAddBoxes.jsx
+++ b/src/features/boxes/AdminAddBoxes.jsx
@@ -164,8 +164,7 @@ function AdminAddBoxes() {
             )}
           </div>
 
-          <div className="mb-4 flex justify-between">
-            <h3 className="text-xl font-semibold text-main-600">紙箱列表</h3>
+          <div className="mb-4 flex justify-end">
             <button
               type="button"
               onClick={() =>
@@ -290,15 +289,19 @@ function AdminAddBoxes() {
             <span className="ml-4 text-neutral-700">{totalPoints}</span>
           </div>
 
-          <div className="mt-6 flex justify-end space-x-4">
+          <div className="mt-6 flex flex-col justify-end gap-4 md:flex-row">
             <button
               type="button"
-              className="btn-cancel"
+              className="btn-cancel order-1"
               onClick={() => navigate("/member/admin/boxesTable")}
             >
               取消
             </button>
-            <button type="submit" className="btn" disabled={isAdding}>
+            <button
+              type="submit"
+              className="btn md:order-2"
+              disabled={isAdding}
+            >
               {isAdding ? "新增中" : "確認"}
             </button>
           </div>

--- a/src/features/boxes/AdminAddBoxes.jsx
+++ b/src/features/boxes/AdminAddBoxes.jsx
@@ -7,6 +7,8 @@ import * as z from "zod";
 
 import { useAddMultipleBoxes } from "@/hooks/boxes/useBoxes";
 import { useCreateTransaction } from "@/hooks/transactions/useCreateTransaction";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 
 const sizeOptions = [
   { label: "特大", value: "特大", points: 5 },
@@ -127,31 +129,33 @@ function AdminAddBoxes() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-main-100 py-6">
-      <div className="mb-3 flex w-1/3 justify-center">
-        <p className="my-5 w-full border-b-4 border-b-main-600 pb-5 text-center text-4xl font-bold text-main-600">
-          新增紙箱
-        </p>
-      </div>
+    <div className="flex flex-col items-center justify-center bg-main-100 px-3 py-6 xl:px-0">
+      <p className="my-5 border-b-4 border-b-main-600 px-3 pb-5 text-center text-4xl font-bold text-main-600">
+        新增紙箱
+      </p>
       <div className="w-full max-w-5xl rounded-xl bg-white p-6 shadow-lg">
         <form onSubmit={handleSubmit(onSubmit)}>
-          <div className="mb-4 space-x-4">
-            <label className="font-semibold text-main-600">新增時間:</label>
-            <input
+          <div className="mb-4 flex items-center space-x-4">
+            <Label className="text-nowrap text-xl font-bold text-main-600">
+              新增時間
+            </Label>
+            <Input
               type="text"
               {...register("created_at")}
               disabled
-              className="rounded-md bg-transparent px-2 py-1 text-neutral-700"
+              className="rounded-md border-none bg-transparent px-2 py-1 text-xl disabled:text-main-600"
             />
           </div>
 
-          <div className="mb-4 space-x-4">
-            <label className="font-semibold text-main-600">會員編號:</label>
-            <input
+          <div className="mb-4 flex items-center space-x-4">
+            <Label className="text-nowrap text-xl font-semibold text-main-600">
+              會員編號
+            </Label>
+            <Input
               type="text"
+              className="w-full max-w-60 border border-neutral-400 focus:border-main-400 focus-visible:outline-none focus-visible:ring-0"
               placeholder="請輸入會員編號"
               {...register("user_id")}
-              className="rounded-md border border-main-400 px-2 py-1 focus-within:border focus-within:border-main-500 focus-visible:outline-none"
             />
             {errors.user_id && (
               <p className="inline text-sm text-red-500">

--- a/src/features/boxes/AdminBoxManageTable.jsx
+++ b/src/features/boxes/AdminBoxManageTable.jsx
@@ -47,9 +47,10 @@ const AdminBoxManageTable = () => {
   // 欄位
   const columns = [
     {
-      name: "紙箱編號",
+      name: "編號",
       selector: (row) => row.id,
       sortable: true,
+      width: "90px",
     },
     {
       name: "紙箱照片",
@@ -75,31 +76,41 @@ const AdminBoxManageTable = () => {
       sortable: true,
       width: "135px",
     },
-    { name: "紙箱大小", selector: (row) => row.size, sortable: true },
+    {
+      name: "紙箱大小",
+      selector: (row) => row.size,
+      sortable: true,
+      width: "110px",
+    },
     {
       name: "保存等級",
       selector: (row) => row.condition,
       sortable: true,
+      width: "110px",
     },
     {
       name: "保留天數",
       selector: (row) => row.retention_days,
       sortable: true,
+      width: "110px",
     },
     {
       name: "紙箱狀態",
       selector: (row) => row.status,
       sortable: true,
+      width: "110px",
     },
     {
-      name: "對應現金",
+      name: "現金",
       selector: (row) => row.cash_value,
       sortable: true,
+      width: "90px",
     },
     {
-      name: "對應積分",
+      name: "積分",
       selector: (row) => row.point_value,
       sortable: true,
+      width: "90px",
     },
     {
       name: "編輯",

--- a/src/features/boxes/AdminBoxManageTable.jsx
+++ b/src/features/boxes/AdminBoxManageTable.jsx
@@ -127,7 +127,7 @@ const AdminBoxManageTable = () => {
   if (boxesError) return <ErrorMessage errorMessage={boxesError.message} />;
 
   return (
-    <>
+    <div className="px-3 lg:px-0">
       <h4 className="mb-4 text-main-600">可認領紙箱列表</h4>
       <StyleSheetManager shouldForwardProp={isPropValid}>
         <DataTable
@@ -139,15 +139,15 @@ const AdminBoxManageTable = () => {
           subHeader
           noDataComponent="沒有紙箱TAT"
           subHeaderComponent={
-            <div className="mb-4 flex w-full justify-between">
+            <div className="mb-4 flex w-full flex-col justify-between gap-3 md:flex-row">
               <input
                 type="text"
                 placeholder="搜尋紙箱編號"
                 value={filterText}
                 onChange={(e) => setFilterText(e.target.value)}
-                className="rounded border p-2 placeholder:text-[#B7B7B7] focus-within:border focus-within:border-main-500 focus-visible:outline-none"
+                className="order-3 rounded border p-2 placeholder:text-[#B7B7B7] focus-within:border focus-within:border-main-500 focus-visible:outline-none md:order-1"
               />
-              <div className="flex gap-5">
+              <div className="order-2 flex justify-end gap-5">
                 <button
                   className="btn flex items-center gap-1 border p-2"
                   onClick={() => {
@@ -169,7 +169,7 @@ const AdminBoxManageTable = () => {
           }
         />
       </StyleSheetManager>
-    </>
+    </div>
   );
 };
 

--- a/src/features/boxes/AdminBoxManageTable.jsx
+++ b/src/features/boxes/AdminBoxManageTable.jsx
@@ -127,7 +127,7 @@ const AdminBoxManageTable = () => {
   if (boxesError) return <ErrorMessage errorMessage={boxesError.message} />;
 
   return (
-    <div className="px-3 lg:px-0">
+    <div className="px-3">
       <h4 className="mb-4 text-main-600">可認領紙箱列表</h4>
       <StyleSheetManager shouldForwardProp={isPropValid}>
         <DataTable

--- a/src/features/boxes/AdminBoxManageTable.jsx
+++ b/src/features/boxes/AdminBoxManageTable.jsx
@@ -126,6 +126,7 @@ const AdminBoxManageTable = () => {
           pagination
           paginationComponentOptions={paginationComponentOptions}
           subHeader
+          noDataComponent="沒有紙箱TAT"
           subHeaderComponent={
             <div className="mb-4 flex w-full justify-between">
               <input

--- a/src/features/boxes/AdminDeprecatedTable.jsx
+++ b/src/features/boxes/AdminDeprecatedTable.jsx
@@ -123,7 +123,7 @@ const AdminDeprecatedTable = () => {
   if (boxesError) return <ErrorMessage errorMessage={boxesError.message} />;
 
   return (
-    <div className="px-3 lg:px-0">
+    <div className="px-3">
       <h4 className="mb-4 text-main-600">待回收紙箱列表</h4>
       <StyleSheetManager shouldForwardProp={isPropValid}>
         <DataTable

--- a/src/features/boxes/AdminDeprecatedTable.jsx
+++ b/src/features/boxes/AdminDeprecatedTable.jsx
@@ -42,7 +42,12 @@ const AdminDeprecatedTable = () => {
 
   // 欄位
   const columns = [
-    { name: "紙箱編號", selector: (row) => row.id, sortable: true },
+    {
+      name: "編號",
+      selector: (row) => row.id,
+      sortable: true,
+      width: "90px",
+    },
     {
       name: "紙箱照片",
       selector: (row) => (
@@ -59,28 +64,50 @@ const AdminDeprecatedTable = () => {
       name: "新增時間",
       selector: (row) => row.created_at?.replace("T", " ").slice(0, 16),
       sortable: true,
-      width: "140px",
+      width: "135px",
     },
     {
       name: "更新時間",
       selector: (row) => row.updated_at?.replace("T", " ").slice(0, 16),
       sortable: true,
-      width: "140px",
+      width: "135px",
     },
-    { name: "紙箱大小", selector: (row) => row.size, sortable: true },
+    {
+      name: "紙箱大小",
+      selector: (row) => row.size,
+      sortable: true,
+      width: "110px",
+    },
     {
       name: "保存等級",
       selector: (row) => row.condition,
       sortable: true,
+      width: "110px",
     },
     {
       name: "保留天數",
       selector: (row) => row.retention_days,
       sortable: true,
+      width: "110px",
     },
-    { name: "紙箱狀態", selector: (row) => row.status, sortable: true },
-    { name: "對應現金", selector: (row) => row.cash_value, sortable: true },
-    { name: "對應積分", selector: (row) => row.point_value, sortable: true },
+    {
+      name: "紙箱狀態",
+      selector: (row) => row.status,
+      sortable: true,
+      width: "110px",
+    },
+    {
+      name: "現金",
+      selector: (row) => row.cash_value,
+      sortable: true,
+      width: "90px",
+    },
+    {
+      name: "積分",
+      selector: (row) => row.point_value,
+      sortable: true,
+      width: "90px",
+    },
     {
       name: "編輯",
       selector: (row) => (

--- a/src/features/boxes/AdminDeprecatedTable.jsx
+++ b/src/features/boxes/AdminDeprecatedTable.jsx
@@ -104,6 +104,7 @@ const AdminDeprecatedTable = () => {
           data={filteredData}
           pagination
           customStyles={customStyles}
+          noDataComponent="沒有紙箱TAT"
           paginationComponentOptions={paginationComponentOptions}
           subHeader
           subHeaderComponent={
@@ -115,11 +116,6 @@ const AdminDeprecatedTable = () => {
                 onChange={(e) => setFilterText(e.target.value)}
                 className="rounded border p-2 placeholder:text-[#B7B7B7] focus-within:border focus-within:border-main-500 focus-visible:outline-none"
               />
-              <div>
-                <button className="btn flex items-center gap-1 border p-2">
-                  <FaTrashAlt /> 清空表單
-                </button>
-              </div>
             </div>
           }
         />

--- a/src/features/boxes/AdminDeprecatedTable.jsx
+++ b/src/features/boxes/AdminDeprecatedTable.jsx
@@ -123,7 +123,7 @@ const AdminDeprecatedTable = () => {
   if (boxesError) return <ErrorMessage errorMessage={boxesError.message} />;
 
   return (
-    <>
+    <div className="px-3 lg:px-0">
       <h4 className="mb-4 text-main-600">待回收紙箱列表</h4>
       <StyleSheetManager shouldForwardProp={isPropValid}>
         <DataTable
@@ -147,7 +147,7 @@ const AdminDeprecatedTable = () => {
           }
         />
       </StyleSheetManager>
-    </>
+    </div>
   );
 };
 

--- a/src/features/boxes/AdminRecyclingBoxForm.jsx
+++ b/src/features/boxes/AdminRecyclingBoxForm.jsx
@@ -17,11 +17,13 @@ function AdminRecyclingBoxForm({ station }) {
       XL: station.available_slots?.XL || 0,
     },
   });
-  const { register, handleSubmit } = form;
+  const { register, handleSubmit, formState } = form;
+  const { errors } = formState;
 
   function onSubmit(available_slots) {
     try {
       updateAvailableSlots({ stationId: station.id, ...available_slots });
+      console.log(available_slots);
       toast.success("提交成功");
       setIsEditing(false);
     } catch (error) {
@@ -50,49 +52,105 @@ function AdminRecyclingBoxForm({ station }) {
         <div className="mb-2 flex gap-2">
           <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
             <input
+              id="S"
               type="text"
               name="S"
-              defaultValue={20}
+              defaultValue={0}
               disabled={!isEditing}
-              {...register("S", { valueAsNumber: true })}
+              {...register("S", {
+                valueAsNumber: true,
+                validate: (fieldValue) => {
+                  if (Number(fieldValue) < 0) {
+                    return "回收紙箱數不可小於0";
+                  }
+                  if (isNaN(fieldValue)) {
+                    return "回收紙箱數不可為空或字串";
+                  }
+                },
+              })}
               className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
             />
-            <label className="fs-7">小紙箱</label>
+            <label className="fs-7" htmlFor="S">
+              小紙箱
+            </label>
           </div>
           <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
             <input
+              id="M"
               type="text"
               name="M"
-              defaultValue={20}
+              defaultValue={0}
               disabled={!isEditing}
-              {...register("M", { valueAsNumber: true })}
+              {...register("M", {
+                valueAsNumber: true,
+                validate: (fieldValue) => {
+                  if (Number(fieldValue) < 0) {
+                    return "回收紙箱數不可小於0";
+                  }
+                  if (isNaN(fieldValue)) {
+                    return "回收紙箱數不可為空或字串";
+                  }
+                },
+              })}
               className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
             />
-            <label className="fs-7">中紙箱</label>
+            <label className="fs-7" htmlFor="M">
+              中紙箱
+            </label>
           </div>
           <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
             <input
+              id="L"
               type="text"
               name="L"
-              defaultValue={20}
+              defaultValue={0}
               disabled={!isEditing}
-              {...register("L", { valueAsNumber: true })}
+              {...register("L", {
+                valueAsNumber: true,
+                validate: (fieldValue) => {
+                  if (Number(fieldValue) < 0) {
+                    return "回收紙箱數不可小於0";
+                  }
+                  if (isNaN(fieldValue)) {
+                    return "回收紙箱數不可為空或字串";
+                  }
+                },
+              })}
               className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
             />
-            <label className="fs-7">大紙箱</label>
+            <label className="fs-7" htmlFor="L">
+              大紙箱
+            </label>
           </div>
           <div className="flex w-1/4 flex-col flex-wrap gap-1 rounded-md bg-main-100 p-2 text-center text-main-600">
             <input
+              id="XL"
               type="text"
               name="XL"
-              defaultValue={20}
+              defaultValue={0}
               disabled={!isEditing}
-              {...register("XL", { valueAsNumber: true })}
+              {...register("XL", {
+                valueAsNumber: true,
+                validate: (fieldValue) => {
+                  if (Number(fieldValue) < 0) {
+                    return "回收紙箱數不可小於0";
+                  }
+                  if (isNaN(fieldValue)) {
+                    return "回收紙箱數不可為空或字串";
+                  }
+                },
+              })}
               className={`w-full bg-transparent text-center text-[24px] font-bold leading-[28.8px] focus:outline-none ${isEditing ? "rounded border-2 border-main-200 bg-white focus:border-main-400" : ""}`}
             />
-            <label className="fs-7">特大紙箱</label>
+            <label className="fs-7" htmlFor="XL">
+              特大紙箱
+            </label>
           </div>
         </div>
+        <p>{errors.S?.message}</p>
+        <p>{errors.M?.message}</p>
+        <p>{errors.L?.message}</p>
+        <p>{errors.XL?.message}</p>
         {isEditing && (
           <button className="btn" type="submit" disabled={isLoading}>
             {isLoading ? "更新中" : "確認修改"}

--- a/src/features/boxes/AdminTrade.jsx
+++ b/src/features/boxes/AdminTrade.jsx
@@ -180,15 +180,15 @@ function AdminTrade() {
                   </div>
                 </div>
 
-                <div className="flex flex-1 justify-end gap-3 self-end">
+                <div className="mt-6 flex flex-col justify-end gap-4 md:flex-row">
                   <button
-                    className="btn-cancel text-xl"
+                    className="btn-cancel order-1"
                     type="button"
                     onClick={() => navigate("/member/admin/boxesTable")}
                   >
                     取消
                   </button>
-                  <button className="btn text-xl" type="submit">
+                  <button className="btn md:order-2" type="submit">
                     確認
                   </button>
                 </div>

--- a/src/features/boxes/AdminTrade.jsx
+++ b/src/features/boxes/AdminTrade.jsx
@@ -113,18 +113,22 @@ function AdminTrade() {
                     {new Date().toLocaleString()}
                   </Label>
                 </div>
-                <div className="mb-5 flex items-center">
-                  <Label className="mr-3 text-nowrap text-xl font-bold text-main-600">
-                    會員編號
-                  </Label>
-                  <Input
-                    className="w-full max-w-60 border border-neutral-400 focus:border-main-400 focus-visible:outline-none focus-visible:ring-0"
-                    type="text"
-                    placeholder="請輸入會員編號"
-                    {...register("userId")}
-                  />
+                <div className="mb-5 flex flex-col md:flex-row">
+                  <div className="flex items-center">
+                    <Label className="mr-3 text-nowrap text-xl font-bold text-main-600">
+                      會員編號
+                    </Label>
+                    <Input
+                      className="w-full max-w-60 border border-neutral-400 focus:border-main-400 focus-visible:outline-none focus-visible:ring-0"
+                      type="text"
+                      placeholder="請輸入會員編號"
+                      {...register("userId")}
+                    />
+                  </div>
                   {errors.userId && (
-                    <p className="ml-5 text-red-500">{errors.userId.message}</p>
+                    <p className="text-red-500 md:ml-5">
+                      {errors.userId.message}
+                    </p>
                   )}
                 </div>
               </div>
@@ -180,15 +184,18 @@ function AdminTrade() {
                   </div>
                 </div>
 
-                <div className="mt-6 flex flex-col justify-end gap-4 md:flex-row">
+                <div className="mt-6 flex flex-col justify-end gap-4 md:w-1/2 md:flex-row">
                   <button
-                    className="btn-cancel order-1"
                     type="button"
+                    className="btn-cancel order-1 h-[42px] md:w-1/2 md:self-end"
                     onClick={() => navigate("/member/admin/boxesTable")}
                   >
                     取消
                   </button>
-                  <button className="btn md:order-2" type="submit">
+                  <button
+                    className="btn h-[42px] md:order-2 md:w-1/2 md:self-end"
+                    type="submit"
+                  >
                     確認
                   </button>
                 </div>

--- a/src/features/boxes/AdminTrade.jsx
+++ b/src/features/boxes/AdminTrade.jsx
@@ -118,7 +118,12 @@ function AdminTrade() {
                   <Label className="mr-5 text-2xl font-bold text-main-600">
                     會員編號
                   </Label>
-                  <Input className="w-72" type="text" {...register("userId")} />
+                  <Input
+                    className="w-72 focus:border-main-400 focus-visible:outline-none focus-visible:ring-0"
+                    type="text"
+                    placeholder="請輸入會員編號"
+                    {...register("userId")}
+                  />
                   {errors.userId && (
                     <p className="ml-5 text-red-500">{errors.userId.message}</p>
                   )}
@@ -149,18 +154,27 @@ function AdminTrade() {
 
               <div className="my-5 flex items-center justify-between">
                 <div className="flex flex-1 flex-col items-start">
-                  <div className="mb-3 flex w-1/2">
-                    <p className="w-1/3 text-xl font-bold">交易紙箱數</p>
-                    <p className="text-xl">{selectedCounts} 個紙箱</p>
+                  <div className="mb-3 flex w-full">
+                    <p className="w-1/3 text-nowrap text-xl font-bold text-main-600">
+                      交易紙箱數
+                    </p>
+                    <p className="w-1/4 rounded-sm px-1 text-xl text-neutral-700">
+                      {selectedCounts} 個紙箱
+                    </p>
                   </div>
-                  <div className="flex w-1/2 items-center">
-                    <p className="w-1/3 text-xl font-bold">支付方式</p>
+                  <div className="flex w-full items-center">
+                    <p className="w-1/3 text-xl font-bold text-main-600">
+                      支付方式
+                    </p>
                     <Controller
                       name="paymentMethod"
                       control={methods.control}
                       defaultValue="cash"
                       render={({ field }) => (
-                        <select className="text-xl" {...field}>
+                        <select
+                          className="w-1/4 rounded-sm border-2 border-main-200 bg-transparent text-xl text-neutral-700 focus-visible:border-main-200 focus-visible:outline-none"
+                          {...field}
+                        >
                           <option value="cash">現金</option>
                           <option value="points">積分</option>
                         </select>
@@ -170,15 +184,15 @@ function AdminTrade() {
                 </div>
 
                 <div className="flex flex-1 gap-3">
-                  <button className="btn w-1/2 text-xl" type="submit">
-                    確認送出
-                  </button>
                   <button
-                    className="btn w-1/2 text-xl"
+                    className="btn-cancel w-1/2 text-xl"
                     type="button"
                     onClick={() => navigate("/member/admin/boxesTable")}
                   >
                     取消
+                  </button>
+                  <button className="btn w-1/2 text-xl" type="submit">
+                    確認送出
                   </button>
                 </div>
               </div>

--- a/src/features/boxes/AdminTrade.jsx
+++ b/src/features/boxes/AdminTrade.jsx
@@ -98,28 +98,27 @@ function AdminTrade() {
     <>
       <FormProvider {...methods}>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <div className="flex min-h-screen flex-col items-center justify-center bg-main-100 py-6">
-            <div className="mb-3 flex w-1/3 justify-center">
-              <p className="my-5 w-full border-b-4 border-b-main-600 pb-5 text-center text-4xl font-bold text-main-600">
-                交易紙箱
-              </p>
-            </div>
+          <div className="flex flex-col items-center justify-center bg-main-100 px-3 py-6 xl:px-0">
+            <p className="my-5 border-b-4 border-b-main-600 px-3 pb-5 text-center text-4xl font-bold text-main-600">
+              交易紙箱
+            </p>
+
             <div className="w-full max-w-5xl rounded-xl bg-white p-5">
-              <div className="w-1/2">
-                <div className="mb-5 flex flex-1 items-center">
-                  <Label className="mr-5 text-2xl font-bold text-main-600">
+              <div>
+                <div className="mb-5">
+                  <Label className="mr-3 text-xl font-bold text-main-600">
                     交易時間
                   </Label>
-                  <Label className="text-2xl text-main-600">
+                  <Label className="text-xl text-main-600">
                     {new Date().toLocaleString()}
                   </Label>
                 </div>
-                <div className="mb-5 flex flex-1 items-center">
-                  <Label className="mr-5 text-2xl font-bold text-main-600">
+                <div className="mb-5 flex items-center">
+                  <Label className="mr-3 text-nowrap text-xl font-bold text-main-600">
                     會員編號
                   </Label>
                   <Input
-                    className="w-72 border border-neutral-400 focus:border-main-400 focus-visible:outline-none focus-visible:ring-0"
+                    className="w-full max-w-60 border border-neutral-400 focus:border-main-400 focus-visible:outline-none focus-visible:ring-0"
                     type="text"
                     placeholder="請輸入會員編號"
                     {...register("userId")}
@@ -152,27 +151,25 @@ function AdminTrade() {
                 </div>
               </div>
 
-              <div className="my-5 flex items-center justify-between">
-                <div className="flex flex-1 flex-col items-start">
-                  <div className="mb-3 flex w-full">
-                    <p className="w-1/3 text-nowrap text-xl font-bold text-main-600">
+              <div className="my-5 flex flex-col justify-between gap-4 md:flex-row">
+                <div className="sm:w-1/2">
+                  <div className="mb-3 flex justify-between">
+                    <p className="text-nowrap text-xl font-bold text-main-600">
                       交易紙箱數
                     </p>
-                    <p className="w-1/4 rounded-sm px-1 text-xl text-neutral-700">
+                    <p className="w-1/2 rounded-sm px-1 text-start text-xl text-neutral-700">
                       {selectedCounts} 個紙箱
                     </p>
                   </div>
-                  <div className="flex w-full items-center">
-                    <p className="w-1/3 text-xl font-bold text-main-600">
-                      支付方式
-                    </p>
+                  <div className="flex items-center justify-between">
+                    <p className="text-xl font-bold text-main-600">支付方式</p>
                     <Controller
                       name="paymentMethod"
                       control={methods.control}
                       defaultValue="cash"
                       render={({ field }) => (
                         <select
-                          className="w-1/4 rounded-md border border-neutral-400 bg-transparent text-xl text-neutral-700 focus-visible:border-main-200 focus-visible:outline-none focus-visible:ring-0"
+                          className="h-9 w-1/2 rounded-md border border-neutral-400 bg-transparent text-xl text-neutral-700 focus-visible:border-main-200 focus-visible:outline-none focus-visible:ring-0"
                           {...field}
                         >
                           <option value="cash">現金</option>

--- a/src/features/boxes/AdminTrade.jsx
+++ b/src/features/boxes/AdminTrade.jsx
@@ -98,13 +98,13 @@ function AdminTrade() {
     <>
       <FormProvider {...methods}>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <div className="z-100 container top-16 mx-auto my-5 flex flex-col items-center justify-center">
+          <div className="flex min-h-screen flex-col items-center justify-center bg-main-100 py-6">
             <div className="mb-3 flex w-1/3 justify-center">
               <p className="my-5 w-full border-b-4 border-b-main-600 pb-5 text-center text-4xl font-bold text-main-600">
                 交易紙箱
               </p>
             </div>
-            <div className="w-full rounded-xl bg-[#fafafa] p-5">
+            <div className="w-full max-w-5xl rounded-xl bg-white p-5">
               <div className="w-1/2">
                 <div className="mb-5 flex flex-1 items-center">
                   <Label className="mr-5 text-2xl font-bold text-main-600">
@@ -119,7 +119,7 @@ function AdminTrade() {
                     會員編號
                   </Label>
                   <Input
-                    className="w-72 focus:border-main-400 focus-visible:outline-none focus-visible:ring-0"
+                    className="w-72 border border-neutral-400 focus:border-main-400 focus-visible:outline-none focus-visible:ring-0"
                     type="text"
                     placeholder="請輸入會員編號"
                     {...register("userId")}
@@ -172,7 +172,7 @@ function AdminTrade() {
                       defaultValue="cash"
                       render={({ field }) => (
                         <select
-                          className="w-1/4 rounded-sm border-2 border-main-200 bg-transparent text-xl text-neutral-700 focus-visible:border-main-200 focus-visible:outline-none"
+                          className="w-1/4 rounded-md border border-neutral-400 bg-transparent text-xl text-neutral-700 focus-visible:border-main-200 focus-visible:outline-none focus-visible:ring-0"
                           {...field}
                         >
                           <option value="cash">現金</option>
@@ -183,16 +183,16 @@ function AdminTrade() {
                   </div>
                 </div>
 
-                <div className="flex flex-1 gap-3">
+                <div className="flex flex-1 justify-end gap-3 self-end">
                   <button
-                    className="btn-cancel w-1/2 text-xl"
+                    className="btn-cancel text-xl"
                     type="button"
                     onClick={() => navigate("/member/admin/boxesTable")}
                   >
                     取消
                   </button>
-                  <button className="btn w-1/2 text-xl" type="submit">
-                    確認送出
+                  <button className="btn text-xl" type="submit">
+                    確認
                   </button>
                 </div>
               </div>

--- a/src/features/boxes/AdminTradeTable.jsx
+++ b/src/features/boxes/AdminTradeTable.jsx
@@ -14,7 +14,9 @@ const customStyles = {
   table: {
     style: {
       border: "1px solid #d9d9d9",
+      borderRadius: "12px",
       boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+      padding: "8px",
     },
   },
   headRow: {
@@ -140,7 +142,7 @@ const AdminTradeTable = ({ handleSelectChange }) => {
           placeholder="請輸入關鍵字搜尋"
           value={filterText}
           onChange={(e) => setFilterText(e.target.value)}
-          className="rounded border p-2"
+          className="rounded border p-2 focus:border-main-400 focus-visible:outline-none"
         />
       </div>
       <DataTable
@@ -151,6 +153,7 @@ const AdminTradeTable = ({ handleSelectChange }) => {
         onSelectedRowsChange={handleSelectChange}
         fixedHeader
         fixedHeaderScrollHeight="350px"
+        noDataComponent="沒有紙箱TAT"
       />
     </StyleSheetManager>
   );

--- a/src/features/boxes/AdminTradeTable.jsx
+++ b/src/features/boxes/AdminTradeTable.jsx
@@ -143,7 +143,7 @@ const AdminTradeTable = ({ handleSelectChange }) => {
           placeholder="請輸入關鍵字搜尋"
           value={filterText}
           onChange={(e) => setFilterText(e.target.value)}
-          className="w-72 border border-neutral-400 focus:border-main-400 focus-visible:outline-none focus-visible:ring-0"
+          className="w-full border border-neutral-400 focus:border-main-400 focus-visible:outline-none focus-visible:ring-0 sm:w-72"
         />
       </div>
       <DataTable

--- a/src/features/boxes/AdminTradeTable.jsx
+++ b/src/features/boxes/AdminTradeTable.jsx
@@ -49,6 +49,7 @@ const customStyles = {
   },
 };
 import PropTypes from "prop-types";
+import { Input } from "@/components/ui/input";
 
 const AdminTradeTable = ({ handleSelectChange }) => {
   // 資料
@@ -137,12 +138,12 @@ const AdminTradeTable = ({ handleSelectChange }) => {
     <StyleSheetManager shouldForwardProp={isPropValid}>
       {/* 搜尋框 */}
       <div className="mb-3 flex w-full justify-start">
-        <input
+        <Input
           type="text"
           placeholder="請輸入關鍵字搜尋"
           value={filterText}
           onChange={(e) => setFilterText(e.target.value)}
-          className="rounded border p-2 focus:border-main-400 focus-visible:outline-none"
+          className="w-72 border border-neutral-400 focus:border-main-400 focus-visible:outline-none focus-visible:ring-0"
         />
       </div>
       <DataTable

--- a/src/features/transactions/AdminTradeHistoryTable.jsx
+++ b/src/features/transactions/AdminTradeHistoryTable.jsx
@@ -66,7 +66,7 @@ const AdminTradeHistoryTable = () => {
   ];
 
   return (
-    <>
+    <div className="px-3 lg:px-0">
       <h4 className="mb-4 text-main-600">紙箱交易紀錄</h4>
       <StyleSheetManager shouldForwardProp={isPropValid}>
         <DataTable
@@ -77,7 +77,7 @@ const AdminTradeHistoryTable = () => {
           paginationComponentOptions={paginationComponentOptions}
         />
       </StyleSheetManager>
-    </>
+    </div>
   );
 };
 

--- a/src/features/transactions/AdminTradeHistoryTable.jsx
+++ b/src/features/transactions/AdminTradeHistoryTable.jsx
@@ -66,7 +66,7 @@ const AdminTradeHistoryTable = () => {
   ];
 
   return (
-    <div className="px-3 lg:px-0">
+    <div className="px-3">
       <h4 className="mb-4 text-main-600">紙箱交易紀錄</h4>
       <StyleSheetManager shouldForwardProp={isPropValid}>
         <DataTable


### PR DESCRIPTION
- 站點概況
  - [ ] 營業時間的星期改為單行顯示，避免換行掉字影響易讀性
  - [ ] 可回收紙箱的 input 新增自定義驗證規則，並新增錯誤提示
    - [ ] 輸入值不可以為空或字串
    - [ ] 輸入值不可小於 0 
- 可認領紙箱列表
  - [ ] 表頭字體改 14px 、表單內容改 16px
  - [ ] 「確認送出」按鈕改放在畫面右下
  - [ ] 調整支付方式的 Dropdown 樣式
  - [ ] 列表無資料時，顯示：沒有紙箱TAT
  - [ ] 搜尋框、新增紙箱、交易紙箱按鈕 響應式調整
  - [ ] 刪除副標題「紙箱列表」
- 交易紙箱、新增紙箱
  - [ ] 交易紙箱表單中的「會員編號」加上 Placeholder
  - [ ] 列表無資料時，顯示：沒有紙箱TAT 
  - [ ] 取消、確認按鈕手機板調整為滿寬、垂直排列
- 待回收紙箱列表
  - [ ] 移除「清空表單」按鈕
  - [ ] 列表無資料時，顯示：沒有紙箱TAT
 
管理者頁面
  - [ ] 新增畫面整體左右 12px 間距
